### PR TITLE
Fix MP3 output corruption

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,12 +12,11 @@ RUN DEBIAN_FRONTEND=noninteractive \
         sudo \
         gdb \
         clang-format-14 \
-        python3-pip
+        python3-pip \
+        pre-commit
 
 WORKDIR /app
 COPY .github/install_dependencies /app/
 RUN /app/install_dependencies
-
-RUN pip install pre-commit
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.github/platform_build
+++ b/.github/platform_build
@@ -14,7 +14,7 @@ case "${platform}" in
         CMAKE_ARGS="-DPLATFORM=rpiv2 -DCMAKE_BUILD_TYPE=Release -DNFM=TRUE -DBUILD_UNITTESTS=TRUE"
         ;;
     ubuntu-22.04-arm)
-        CMAKE_ARGS="-DPLATFORM=rpiv2 -DCMAKE_BUILD_TYPE=Release -DNFM=TRUE -DBUILD_UNITTESTS=TRUE"
+        CMAKE_ARGS="-DPLATFORM=native -DCMAKE_BUILD_TYPE=Release -DNFM=TRUE -DBUILD_UNITTESTS=TRUE"
         ;;
 
     *)

--- a/.github/platform_build
+++ b/.github/platform_build
@@ -13,6 +13,9 @@ case "${platform}" in
     rpi3b)
         CMAKE_ARGS="-DPLATFORM=rpiv2 -DCMAKE_BUILD_TYPE=Release -DNFM=TRUE -DBUILD_UNITTESTS=TRUE"
         ;;
+    ubuntu-22.04-arm)
+        CMAKE_ARGS="-DPLATFORM=rpiv2 -DCMAKE_BUILD_TYPE=Release -DNFM=TRUE -DBUILD_UNITTESTS=TRUE"
+        ;;
 
     *)
         echo "Error: Platform '${platform}' not supported"

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ jobs:
   ci_build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, ubuntu-20.04-arm ]
+        os: [ ubuntu-22.04, macos-13, macos-14, ubuntu-20.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ jobs:
   ci_build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, macos-13, ubuntu-20.04 ]
+        os: [ ubuntu-22.04, macos-13, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ jobs:
   ci_build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-14, ubuntu-20.04-arm ]
+        os: [ ubuntu-22.04, macos-13, macos-14, ubuntu-22.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ jobs:
   ci_build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, ubuntu-20.04 ]
+        os: [ ubuntu-22.04, macos-13, ubuntu-20.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/.github/workflows/platform_build.yml
+++ b/.github/workflows/platform_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # os: [ rpi3b ]
-        os: [ ubuntu-20.04-arm ]
+        os: [ ubuntu-22.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/.github/workflows/platform_build.yml
+++ b/.github/workflows/platform_build.yml
@@ -13,7 +13,8 @@ jobs:
   platform_build:
     strategy:
       matrix:
-        os: [ rpi3b ]
+        # os: [ rpi3b ]
+        os: [ ubuntu-20.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:

--- a/scripts/find_version
+++ b/scripts/find_version
@@ -5,7 +5,7 @@ PROJECT_GIT_DIR_PATH="${PROJECT_ROOT_PATH}/.git"
 PROJECT_DIR_NAME="$(basename ${PROJECT_ROOT_PATH})"
 
 # if there is a .git directory at the project root then rely on git for the version string
-if [ -d "${PROJECT_GIT_DIR_PATH}" ] ; then
+if [ -r "${PROJECT_GIT_DIR_PATH}" ] ; then
     git describe --tags --abbrev --dirty --always
     exit 0
 fi

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -312,25 +312,27 @@ static int open_file(file_data* fdata, mix_modes mixmode, int is_audio) {
     return 0;
 }
 
-static void close_file(channel_t* channel, file_data* fdata) {
+static void close_file(output_t* output) {
+    file_data* fdata = (file_data*)(output->data);
     if (!fdata) {
         return;
     }
 
-    if (fdata->type == O_FILE && fdata->f && channel->lame) {
-        int encoded = lame_encode_flush_nogap(channel->lame, channel->lamebuf, LAMEBUF_SIZE);
+    // close all mp3 files for every output that has a lame context
+    if (fdata->type == O_FILE && fdata->f && output->lame) {
+        int encoded = lame_encode_flush_nogap(output->lame, output->lamebuf, LAMEBUF_SIZE);
         debug_print("closing file %s flushed %d\n", fdata->file_path.c_str(), encoded);
 
         if (encoded > 0) {
-            size_t written = fwrite((void*)channel->lamebuf, 1, (size_t)encoded, fdata->f);
+            size_t written = fwrite((void*)output->lamebuf, 1, (size_t)encoded, fdata->f);
             if (written == 0 || written < (size_t)encoded)
                 log(LOG_WARNING, "Problem writing %s (%s)\n", fdata->file_path.c_str(), strerror(errno));
         }
 
         // write the lametag to the beginning of the file
-        const int lametag_size = lame_get_lametag_frame(channel->lame, channel->lamebuf, LAMEBUF_SIZE);
+        const int lametag_size = lame_get_lametag_frame(output->lame, output->lamebuf, LAMEBUF_SIZE);
         fseek(fdata->f, 0, SEEK_SET);
-        fwrite(channel->lamebuf, 1, lametag_size, fdata->f);
+        fwrite(output->lamebuf, 1, lametag_size, fdata->f);
     }
 
     if (fdata->f) {
@@ -349,7 +351,9 @@ static void close_file(channel_t* channel, file_data* fdata) {
  * else (append or continuous) check:
  *   if hour is different.
  */
-static void close_if_necessary(channel_t* channel, file_data* fdata) {
+static void close_if_necessary(output_t* output) {
+    file_data* fdata = (file_data*)(output->data);
+
     static const double MIN_TRANSMISSION_TIME_SEC = 1.0;
     static const double MAX_TRANSMISSION_TIME_SEC = 60.0 * 60.0;
     static const double MAX_TRANSMISSION_IDLE_SEC = 0.5;
@@ -367,7 +371,7 @@ static void close_if_necessary(channel_t* channel, file_data* fdata) {
 
         if (duration_sec > MAX_TRANSMISSION_TIME_SEC || (duration_sec > MIN_TRANSMISSION_TIME_SEC && idle_sec > MAX_TRANSMISSION_IDLE_SEC)) {
             debug_print("closing file %s, duration %f sec, idle %f sec\n", fdata->file_path.c_str(), duration_sec, idle_sec);
-            close_file(channel, fdata);
+            close_file(output);
         }
         return;
     }
@@ -386,7 +390,7 @@ static void close_if_necessary(channel_t* channel, file_data* fdata) {
 
     if (start_hour != current_hour) {
         debug_print("closing file %s after crossing hour boundary\n", fdata->file_path.c_str());
-        close_file(channel, fdata);
+        close_file(output);
     }
 }
 
@@ -398,12 +402,13 @@ static void close_if_necessary(channel_t* channel, file_data* fdata) {
  * Otherwise, create a file name based on the current timestamp and
  * open that new file.  If that file open succeeded, return true.
  */
-static bool output_file_ready(channel_t* channel, file_data* fdata, mix_modes mixmode, int is_audio) {
+static bool output_file_ready(channel_t* channel, output_t* output) {
+    file_data* fdata = (file_data*)(output->data);
     if (!fdata) {
         return false;
     }
 
-    close_if_necessary(channel, fdata);
+    close_if_necessary(output);
 
     if (fdata->f) {  // still open
         return true;
@@ -449,7 +454,8 @@ static bool output_file_ready(channel_t* channel, file_data* fdata, mix_modes mi
 
     fdata->open_time = fdata->last_write_time = current_time;
 
-    if (open_file(fdata, mixmode, is_audio) < 0) {
+    const int is_audio = output->type == O_RAWFILE ? 0 : 1;
+    if (open_file(fdata, channel->mode, is_audio) < 0) {
         log(LOG_WARNING, "Cannot open output file %s (%s)\n", fdata->file_path_tmp.c_str(), strerror(errno));
         return false;
     }
@@ -459,21 +465,28 @@ static bool output_file_ready(channel_t* channel, file_data* fdata, mix_modes mi
 
 // Create all the output for a particular channel.
 void process_outputs(channel_t* channel, int cur_scan_freq) {
-    int mp3_bytes = 0;
-    if (channel->need_mp3) {
-        // debug_bulk_print("channel->mode=%s\n", channel->mode == MM_STEREO ? "MM_STEREO" : "MM_MONO");
-        mp3_bytes = lame_encode_buffer_ieee_float(channel->lame, channel->waveout, (channel->mode == MM_STEREO ? channel->waveout_r : NULL), WAVE_BATCH, channel->lamebuf, LAMEBUF_SIZE);
-        if (mp3_bytes < 0)
-            log(LOG_WARNING, "lame_encode_buffer_ieee_float: %d\n", mp3_bytes);
-    }
     for (int k = 0; k < channel->output_count; k++) {
         if (channel->outputs[k].enabled == false)
             continue;
         if (channel->outputs[k].type == O_ICECAST) {
             icecast_data* icecast = (icecast_data*)(channel->outputs[k].data);
-            if (icecast->shout == NULL || mp3_bytes <= 0)
+            if (icecast->shout == NULL)
                 continue;
-            int ret = shout_send(icecast->shout, channel->lamebuf, mp3_bytes);
+
+            // encode and send mp3 to shoutcast output
+            const auto& lame = channel->outputs[k].lame;
+            const auto& lamebuf = channel->outputs[k].lamebuf;
+            int mp3_bytes = lame_encode_buffer_ieee_float(lame, channel->waveout, (channel->mode == MM_STEREO ? channel->waveout_r : NULL), WAVE_BATCH, lamebuf, LAMEBUF_SIZE);
+            if (mp3_bytes < 0) {
+                log(LOG_WARNING, "lame_encode_buffer_ieee_float: %d\n", mp3_bytes);
+            }
+
+            if (mp3_bytes == 0) {
+                continue;
+            }
+
+            int ret = shout_send(icecast->shout, channel->outputs[k].lamebuf, mp3_bytes);
+
             if (ret != SHOUTERR_SUCCESS || shout_queuelen(icecast->shout) > MAX_SHOUT_QUEUELEN) {
                 if (shout_queuelen(icecast->shout) > MAX_SHOUT_QUEUELEN)
                     log(LOG_WARNING, "Exceeded max backlog for %s:%d/%s, disconnecting\n", icecast->hostname, icecast->port, icecast->mountpoint);
@@ -504,23 +517,35 @@ void process_outputs(channel_t* channel, int cur_scan_freq) {
             file_data* fdata = (file_data*)(channel->outputs[k].data);
 
             if (fdata->continuous == false && channel->axcindicate == NO_SIGNAL && channel->outputs[k].active == false) {
-                close_if_necessary(channel, fdata);
+                close_if_necessary(&channel->outputs[k]);
                 continue;
             }
 
-            if (channel->outputs[k].type == O_FILE && mp3_bytes <= 0)
-                continue;
-
-            if (!output_file_ready(channel, fdata, channel->mode, (channel->outputs[k].type == O_RAWFILE ? 0 : 1))) {
+            if (!output_file_ready(channel, &channel->outputs[k])) {
                 log(LOG_WARNING, "Output disabled\n");
                 channel->outputs[k].enabled = false;
                 continue;
             };
 
+            // encode mp3 bytes if O_FILE
+            const auto& lame = channel->outputs[k].lame;
+            const auto& lamebuf = channel->outputs[k].lamebuf;
+            int mp3_bytes = 0;
+            if (channel->outputs[k].type == O_FILE) {
+                mp3_bytes = lame_encode_buffer_ieee_float(lame, channel->waveout, (channel->mode == MM_STEREO ? channel->waveout_r : NULL), WAVE_BATCH, lamebuf, LAMEBUF_SIZE);
+                if (mp3_bytes < 0) {
+                    log(LOG_WARNING, "lame_encode_buffer_ieee_float: %d\n", mp3_bytes);
+                }
+
+                if (mp3_bytes <= 0) {
+                    continue;
+                }
+            }
+
             size_t buflen = 0, written = 0;
             if (channel->outputs[k].type == O_FILE) {
                 buflen = (size_t)mp3_bytes;
-                written = fwrite(channel->lamebuf, 1, buflen, fdata->f);
+                written = fwrite(lamebuf, 1, buflen, fdata->f);
             } else if (channel->outputs[k].type == O_RAWFILE) {
                 buflen = 2 * sizeof(float) * WAVE_BATCH;
                 written = fwrite(channel->iq_out, 1, buflen, fdata->f);
@@ -530,7 +555,7 @@ void process_outputs(channel_t* channel, int cur_scan_freq) {
                     log(LOG_WARNING, "Cannot write to %s (%s), output disabled\n", fdata->file_path.c_str(), strerror(errno));
                 else
                     log(LOG_WARNING, "Short write on %s, output disabled\n", fdata->file_path.c_str());
-                close_file(channel, fdata);
+                close_file(&channel->outputs[k]);
                 channel->outputs[k].enabled = false;
             }
             channel->outputs[k].active = (channel->axcindicate != NO_SIGNAL);
@@ -576,8 +601,7 @@ void disable_channel_outputs(channel_t* channel) {
             shout_free(icecast->shout);
             icecast->shout = NULL;
         } else if (output->type == O_FILE || output->type == O_RAWFILE) {
-            file_data* fdata = (file_data*)(channel->outputs[k].data);
-            close_file(channel, fdata);
+            close_file(&channel->outputs[k]);
         } else if (output->type == O_MIXER) {
             mixer_data* mdata = (mixer_data*)(output->data);
             mixer_disable_input(mdata->mixer, mdata->input);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -326,6 +326,11 @@ static void close_file(channel_t* channel, file_data* fdata) {
             if (written == 0 || written < (size_t)encoded)
                 log(LOG_WARNING, "Problem writing %s (%s)\n", fdata->file_path.c_str(), strerror(errno));
         }
+
+        // write the lametag to the beginning of the file
+        const int lametag_size = lame_get_lametag_frame(channel->lame, channel->lamebuf, LAMEBUF_SIZE);
+        fseek(fdata->f, 0, SEEK_SET);
+        fwrite(channel->lamebuf, 1, lametag_size, fdata->f);
     }
 
     if (fdata->f) {

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -947,10 +947,6 @@ int main(int argc, char* argv[]) {
             continue;  // no inputs connected = no need to initialize output
         }
         channel_t* channel = &mixers[i].channel;
-        if (channel->need_mp3) {
-            channel->lame = airlame_init(mixers[i].channel.mode, mixers[i].channel.highpass, mixers[i].channel.lowpass);
-            channel->lamebuf = (unsigned char*)malloc(sizeof(unsigned char) * LAMEBUF_SIZE);
-        }
         for (int k = 0; k < channel->output_count; k++) {
             output_t* output = channel->outputs + k;
             if (output->type == O_ICECAST) {
@@ -974,12 +970,6 @@ int main(int argc, char* argv[]) {
         for (int j = 0; j < dev->channel_count; j++) {
             channel_t* channel = dev->channels + j;
 
-            // If the channel has icecast or MP3 file output, we will attempt to
-            // initialize a separate LAME context for MP3 encoding.
-            if (channel->need_mp3) {
-                channel->lame = airlame_init(channel->mode, channel->highpass, channel->lowpass);
-                channel->lamebuf = (unsigned char*)malloc(sizeof(unsigned char) * LAMEBUF_SIZE);
-            }
             for (int k = 0; k < channel->output_count; k++) {
                 output_t* output = channel->outputs + k;
                 if (output->type == O_ICECAST) {
@@ -1150,8 +1140,11 @@ int main(int argc, char* argv[]) {
         device_t* dev = devices + i;
         for (int j = 0; j < dev->channel_count; j++) {
             channel_t* channel = dev->channels + j;
-            if (channel->need_mp3 && channel->lame) {
-                lame_close(channel->lame);
+            for (int k = 0; k < channel->output_count; k++) {
+                output_t* output = channel->outputs + k;
+                if (output->lame) {
+                    lame_close(output->lame);
+                }
             }
         }
     }

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -183,6 +183,10 @@ struct output_t {
     bool enabled;
     bool active;
     void* data;
+
+    // set if this output performs mp3 encoding
+    lame_t lame;
+    unsigned char* lamebuf;  // temporary buffer used for lame encoding
 };
 
 struct freq_tag {
@@ -250,16 +254,13 @@ struct channel_t {
     struct freq_t* freqlist;
     int freq_count;
     int freq_idx;
-    int need_mp3;
     int needs_raw_iq;
     int has_iq_outputs;
     enum ch_states state;  // mixer channel state flag
     int output_count;
     output_t* outputs;
-    int highpass;            // highpass filter cutoff
-    int lowpass;             // lowpass filter cutoff
-    lame_t lame;             // Context for LAME MP3 encoding if needed
-    unsigned char* lamebuf;  // Buffer used by each lame encode
+    int highpass;  // highpass filter cutoff
+    int lowpass;   // lowpass filter cutoff
 };
 
 enum rec_modes { R_MULTICHANNEL, R_SCAN };


### PR DESCRIPTION
# Overview

This PR fixes issue #410, specifically two issues identified with MP3 outputs:

* Missing initial header in MP3 files.
* Bad headers distributed throughout files.

# Details

* Writes the "lametag" initial header just prior to file close.
* Associates `lame_t` instance lifecycle with outputs, instead of channels. Every MP3 output now has its own MP3 encoding context.

# Testing

- [x] Initial smoke-test
- [x] 24h on Rpi4 scanner box
- [x] Community testing by users that have reported associated issues