### PR TITLE
Added configurable stats update interval

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -835,8 +835,8 @@ void write_stats_file(timeval *last_stats_write) {
 	timeval current_time;
 	gettimeofday(&current_time, NULL);
 
-	static const double STATS_FILE_TIMING = 15.0;
-	if (!do_exit && delta_sec(last_stats_write, &current_time) < STATS_FILE_TIMING) {
+	extern int stats_update_interval;
+	if (!do_exit && delta_sec(last_stats_write, &current_time) < stats_update_interval ) {
 		return;
 	}
 

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -82,6 +82,7 @@ bool log_scan_activity = false;
 char *stats_filepath = NULL;
 size_t fft_size_log = DEFAULT_FFT_SIZE_LOG;
 size_t fft_size = 1 << fft_size_log;
+int stats_update_interval = 15; // Stats update every 15 seconf by default
 
 #ifdef NFM
 float alpha = exp(-1.0f/(WAVE_RATE * 2e-4));
@@ -846,6 +847,10 @@ int main(int argc, char* argv[]) {
 			log_scan_activity = true;
 		if(root.exists("stats_filepath"))
 			stats_filepath = strdup(root["stats_filepath"]);
+        	if (root.exists("stats_update_interval")) {
+            		stats_update_interval = (int)root["stats_update_interval"];
+        	}
+
 #ifdef NFM
 		if(root.exists("tau"))
 			alpha = ((int)root["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)root["tau"])));

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -348,6 +348,7 @@ extern volatile int do_exit, device_opened;
 extern float alpha;
 extern device_t *devices;
 extern mixer_t *mixers;
+extern int stats_update_interval;
 
 // util.cpp
 int atomic_inc(volatile int *pv);


### PR DESCRIPTION
As I mentioned in https://github.com/rtl-airband/RTLSDR-Airband/issues/505, I am proposing the ability to modify the update interval of the statistics file. Despite the compilation error due to issues in the unstable branch, I am submitting this PR to showcase the necessary code changes to declare the update-stats-frequency variable, which is an integer that defines how many seconds will pass before the file is updated. This file will then be read by Prometheus.

Now, it would only be necessary to add the global variable **update-stats-frequency = x;**  in the configuration file (rtl_airband.conf) so that each user can control the frequency at which the statistics are updated. The modified code still maintains the default 15-second interval if this global variable is not specified, just like the original code does.

The reason for proposing this change is that having the option to configure a shorter update interval and allowing Prometheus to read these values more frequently enables more precise statistics, especially for analyzing signal and noise levels, for example.

Thank you, and I apologize for any mistakes that may exist. I'm not very experienced with Git and pull requests.




