### PR TITLE
Delay initialization of lame (mp3) context until after config parsing is complete

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -34,6 +34,7 @@ using namespace std;
 static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, int j, bool parsing_mixers) {
     int oo = 0;
     for (int o = 0; o < channel->output_count; o++) {
+        channel->outputs[oo].has_mp3_output = false;
         channel->outputs[oo].lame = NULL;
         channel->outputs[oo].lamebuf = NULL;
 
@@ -95,8 +96,7 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             }
 #endif /* LIBSHOUT_HAS_TLS */
 
-            channel->outputs[oo].lame = airlame_init(channel->mode, channel->highpass, channel->lowpass);
-            channel->outputs[oo].lamebuf = (unsigned char*)malloc(sizeof(unsigned char) * LAMEBUF_SIZE);
+            channel->outputs[oo].has_mp3_output = true;
         } else if (!strncmp(outs[o]["type"], "file", 4)) {
             channel->outputs[oo].data = XCALLOC(1, sizeof(struct file_data));
             channel->outputs[oo].type = O_FILE;
@@ -122,8 +122,7 @@ static int parse_outputs(libconfig::Setting& outs, channel_t* channel, int i, in
             fdata->split_on_transmission = outs[o].exists("split_on_transmission") ? (bool)(outs[o]["split_on_transmission"]) : false;
             fdata->include_freq = outs[o].exists("include_freq") ? (bool)(outs[o]["include_freq"]) : false;
 
-            channel->outputs[oo].lame = airlame_init(channel->mode, channel->highpass, channel->lowpass);
-            channel->outputs[oo].lamebuf = (unsigned char*)malloc(sizeof(unsigned char) * LAMEBUF_SIZE);
+            channel->outputs[oo].has_mp3_output = true;
 
             if (fdata->split_on_transmission) {
                 if (parsing_mixers) {

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -265,7 +265,7 @@ void init_demod(demod_params_t* params, Signal* signal, int device_start, int de
 #endif /* WITH_BCM_VC */
 }
 
-void init_output(output_params_t* params, int device_start, int device_end, int mixer_start, int mixer_end) {
+void init_output_params(output_params_t* params, int device_start, int device_end, int mixer_start, int mixer_end) {
     assert(params != NULL);
 
     params->mp3_signal = new Signal;
@@ -1055,7 +1055,7 @@ int main(int argc, char* argv[]) {
 
     // Setup the output and demod threads
     if (multiple_output_threads == false) {
-        init_output(&output_params[0], 0, device_count, 0, mixer_count);
+        init_output_params(&output_params[0], 0, device_count, 0, mixer_count);
 
         if (multiple_demod_threads == false) {
             init_demod(&demod_params[0], output_params[0].mp3_signal, 0, device_count);
@@ -1066,16 +1066,16 @@ int main(int argc, char* argv[]) {
         }
     } else {
         if (multiple_demod_threads == false) {
-            init_output(&output_params[0], 0, device_count, 0, 0);
+            init_output_params(&output_params[0], 0, device_count, 0, 0);
             init_demod(&demod_params[0], output_params[0].mp3_signal, 0, device_count);
         } else {
             for (int i = 0; i < device_count; i++) {
-                init_output(&output_params[i], i, i + 1, 0, 0);
+                init_output_params(&output_params[i], i, i + 1, 0, 0);
                 init_demod(&demod_params[i], output_params[i].mp3_signal, i, i + 1);
             }
         }
         if (mixer_count > 0) {
-            init_output(&output_params[output_thread_count - 1], 0, 0, 0, mixer_count);
+            init_output_params(&output_params[output_thread_count - 1], 0, 0, 0, mixer_count);
         }
     }
 

--- a/src/rtl_airband.cpp
+++ b/src/rtl_airband.cpp
@@ -266,6 +266,10 @@ void init_demod(demod_params_t* params, Signal* signal, int device_start, int de
 }
 
 bool init_output(channel_t* channel, output_t* output) {
+    if (output->has_mp3_output) {
+        output->lame = airlame_init(channel->mode, channel->highpass, channel->lowpass);
+        output->lamebuf = (unsigned char*)malloc(sizeof(unsigned char) * LAMEBUF_SIZE);
+    }
     if (output->type == O_ICECAST) {
         shout_setup((icecast_data*)(output->data), channel->mode);
     } else if (output->type == O_UDP_STREAM) {

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -184,9 +184,14 @@ struct output_t {
     bool active;
     void* data;
 
-    // set if this output performs mp3 encoding
+    // set to true in order to initialize `lame` and `lamebuf` after config parsing
+    // is complete
+    bool has_mp3_output;
+
+    // lame encoder and buffer for mp3 output. initialized after config parsing
+    // if `uses_mp3_output` is true
     lame_t lame;
-    unsigned char* lamebuf;  // temporary buffer used for lame encoding
+    unsigned char* lamebuf;
 };
 
 struct freq_tag {


### PR DESCRIPTION
Fixes #508 

Correctly initializing the lame context requires config parsing to have been completed: only after config parsing is complete is it known if a channel will require stereo output due to a configured mixer with L/R balance.

Also includes:

* A little renaming for clarity
* Light refactor of duplicated code into func