### PR TITLE
stablize system tests and fix bugs

### DIFF
--- a/.github/workflows/platform_build.yml
+++ b/.github/workflows/platform_build.yml
@@ -16,12 +16,14 @@ jobs:
         include:
           - runner: pi_4b
             platform: native
-            sudo: true
+            sudo: false
             uv_cmd: ~/.local/bin/uv
+            test_output_dir: /test_data
           - runner: ubuntu-22.04-arm
             platform: native
             sudo: false
             uv_cmd: uv
+            test_output_dir: ''
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
@@ -52,10 +54,12 @@ jobs:
     - name: Run system tests
       env:
         SUDO_FLAG: ${{ matrix.sudo == true && '--sudo' || '' }}
+        TEST_OUTPUT_DIR: ${{ matrix.test_output_dir }}
       run: |
         ${{ matrix.uv_cmd }} run --no-group dev pytest system_tests/tests/ \
           --binary builds/Release/src/rtl_airband \
           $SUDO_FLAG \
+          ${TEST_OUTPUT_DIR:+--test-output-dir=$TEST_OUTPUT_DIR} \
           --mode thorough \
           --clean \
           -v

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -343,6 +343,9 @@ static void close_file(output_t* output) {
         const int lametag_size = lame_get_lametag_frame(output->lame, output->lamebuf, LAMEBUF_SIZE);
         fseek(fdata->f, 0, SEEK_SET);
         fwrite(output->lamebuf, 1, lametag_size, fdata->f);
+
+        // Reset the encoder bitstream so the frame count is correct for the next file
+        lame_init_bitstream(output->lame);
     }
 
     if (fdata->f) {

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -209,22 +209,32 @@ enum modulations {
 
 class Signal {
    public:
-    Signal(void) {
+    Signal(void) : pending_(false) {
         pthread_cond_init(&cond_, NULL);
         pthread_mutex_init(&mutex_, NULL);
     }
+    // pending_ is the predicate so a send() that races ahead of wait() is not
+    // lost: the next wait() returns immediately instead of blocking for the
+    // *next* send. Without this the demod thread overruns its first batch
+    // every time its initial send() arrives before the output thread reaches
+    // its first wait().
     void send(void) {
         pthread_mutex_lock(&mutex_);
+        pending_ = true;
         pthread_cond_signal(&cond_);
         pthread_mutex_unlock(&mutex_);
     }
     void wait(void) {
         pthread_mutex_lock(&mutex_);
-        pthread_cond_wait(&cond_, &mutex_);
+        while (!pending_) {
+            pthread_cond_wait(&cond_, &mutex_);
+        }
+        pending_ = false;
         pthread_mutex_unlock(&mutex_);
     }
 
    private:
+    bool pending_;
     pthread_cond_t cond_;
     pthread_mutex_t mutex_;
 };

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -1,6 +1,6 @@
 # System Tests
 
-End-to-end tests that run the actual `rtl_airband` binary against synthetically generated IQ files and validate the audio output (MP3 duration, rawfile size, and Prometheus stats).
+End-to-end tests that run the actual `rtl_airband` binary against synthetically generated IQ files and validate the audio output (MP3 duration and Prometheus stats).
 
 ## How It Works
 
@@ -8,7 +8,7 @@ Each test:
 1. Generates (or loads from cache) a synthetic IQ fixture in RTL-SDR U8 format
 2. Writes a `libconfig++` config file pointing the binary at that IQ file
 3. Runs the binary and waits for it to finish
-4. Validates the output files (`.cf32` rawfiles and MP3s) and the Prometheus stats file
+4. Validates the output MP3s and the Prometheus stats file
 
 IQ fixtures are cached in `.generated_input/` and reused across runs. Test outputs land in `test_output/<test-name>/` and are kept for debugging.
 
@@ -41,27 +41,40 @@ The `--nfm-binary` argument is optional. If omitted, NFM tests are skipped.
 
 ### Test Modes
 
-Pass `--mode` to trade off speed vs. precision:
+Pass `--mode` to trade off wall-clock time vs. strictness. MP3 duration tolerance is a flat ±10% in both modes; what differs is how many output-thread overruns the assertion will tolerate.
 
-| Mode | Tolerance | Parallelism |
-|------|-----------|-------------|
-| `fast` (default) | ±25%, 10x speedup | Safe to run with `-n auto` |
-| `thorough` | ±15% | Must run serially (no `-n`) |
+| Mode | Speedup | Overrun budget | Parallelism |
+|------|---------|----------------|-------------|
+| `thorough` (default) | 1x (real time) | up to 1 (first-batch warm-up) | Must run serially (no `-n`) |
+| `fast` | 10x | up to 5 batches | Safe to run with `-n auto` |
 
 ```bash
 # Fast parallel run
 uv run pytest tests/ --binary ../builds/Release/src/rtl_airband -n auto --mode fast
 
-# Precise serial run
+# Strict serial run
 uv run pytest tests/ --binary ../builds/Release/src/rtl_airband --mode thorough
 ```
+
+### Output directory
+
+By default tests write per-test artifacts under `system_tests/test_output/<test-name>/`. On hosts where SD-card writeback stalls inject timing jitter (notably the Pi 4B CI runner), point this at a tmpfs:
+
+```bash
+uv run pytest tests/ --binary ../builds/Release/src/rtl_airband --test-output-dir=/test_data
+```
+
+The `--test-output-dir` path must exist and be writable by the test process. The cleanup logic in `conftest.py` only wipes the *contents* of the directory, never the directory itself, so it is safe to point at a pre-mounted tmpfs.
+
+The CI runner is provisioned with a `/test_data` tmpfs mount; the workflow at `.github/workflows/platform_build.yml` uses it via `--test-output-dir=/test_data`. The `ubuntu-22.04-arm` runner has fast enough storage that it stays on the default path.
 
 ## Test Coverage
 
 | Test file | What it checks |
 |-----------|----------------|
 | `test_am_squelch_closed.py` | Noise-only input → no output (squelch blocks it) |
-| `test_am_squelch_open.py` | AM signal → rawfile and MP3 with correct duration |
+| `test_am_squelch_open.py` | AM signal opens the squelch → MP3 with correct duration |
+| `test_squelch_disabled.py` | `squelch_snr_threshold = 0` → gate is always open, MP3 produced |
 | `test_ctcss.py` | Correct CTCSS tone opens gate; wrong tone keeps it closed |
 | `test_multichannel.py` | Two simultaneous AM channels each produce independent audio |
 | `test_nfm.py` | NFM demodulation produces correct-duration audio (NFM binary only) |

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -15,7 +15,22 @@ from typing import Any
 import pytest
 
 CACHE_DIR = Path(__file__).parent / ".generated_input"
-TEST_OUTPUT_DIR = Path(__file__).parent / "test_output"
+DEFAULT_TEST_OUTPUT_DIR = Path(__file__).parent / "test_output"
+
+
+def _resolve_test_output_dir(config: pytest.Config) -> Path:
+    """Return the base directory under which each test creates its own subdir.
+
+    Defaults to system_tests/test_output; can be overridden with
+    --test-output-dir, useful for pointing at a tmpfs on hosts where SD-card
+    writeback stalls perturb timing-sensitive tests.
+    """
+    try:
+        override = config.getoption("--test-output-dir")
+    except ValueError:
+        override = None
+    return Path(override) if override else DEFAULT_TEST_OUTPUT_DIR
+
 
 _use_sudo: bool = False
 
@@ -39,8 +54,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         choices=["fast", "thorough"],
         default="thorough",
         help=(
-            "Test mode: 'fast' (25%% tolerances, 10x speedup, use with -n auto for parallel) "
-            "or 'thorough' (15%% tolerances, 1x speedup, serial)"
+            "Test mode: 'fast' (replay speedup, allows some output overruns, "
+            "use with -n auto for parallel) or 'thorough' (no speedup, "
+            "first-batch warm-up overrun budget only, serial)."
         ),
     )
     parser.addoption(
@@ -54,6 +70,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         default=False,
         help="Delete the .generated_input cache before running tests",
+    )
+    parser.addoption(
+        "--test-output-dir",
+        default=None,
+        help=(
+            "Override the base directory used for per-test output (default: "
+            "system_tests/test_output). Point this at a tmpfs to remove disk-"
+            "writeback jitter from timing-sensitive tests on slow-storage hosts."
+        ),
     )
 
 
@@ -93,11 +118,15 @@ def pytest_configure(config: pytest.Config) -> None:
     except ValueError:
         pass
 
-    try:
-        if TEST_OUTPUT_DIR.exists():
-            shutil.rmtree(TEST_OUTPUT_DIR)
-    except ValueError:
-        pass
+    test_output_base = _resolve_test_output_dir(config)
+    if test_output_base.exists():
+        # Clean only contents, not the directory itself — the caller may have
+        # set up the path as a mount point (e.g. tmpfs) we shouldn't unlink.
+        for child in test_output_base.iterdir():
+            if child.is_dir():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
 
     binary_val = None
     nfm_val = None
@@ -126,8 +155,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
         config._rtlsdr_am_binaries = bins
 
-    # Reject --mode thorough with -n (parallel execution raises overrun rates,
-    # which is incompatible with thorough mode's tighter tolerances).
+    # Reject --mode thorough with -n. Thorough mode caps output overruns at 1
+    # (first-batch warm-up only); parallel pytest-xdist workers contending for
+    # CPU produce more than that and would fail the assertion.
     try:
         mode = config.getoption("--mode")
         numprocesses = getattr(config.option, "numprocesses", None)
@@ -138,8 +168,8 @@ def pytest_configure(config: pytest.Config) -> None:
     if mode == "thorough" and numprocesses not in (None, 0, "0"):
         pytest.exit(
             "ERROR: --mode thorough is incompatible with -n / --numprocesses. "
-            "Thorough mode runs serially to ensure tight tolerances are meaningful. "
-            "Use --mode fast for parallel runs.",
+            "Thorough mode runs serially so the tight overrun budget stays "
+            "meaningful. Use --mode fast for parallel runs.",
             returncode=4,
         )
 
@@ -172,9 +202,10 @@ def ensure_cache_dir() -> None:
 
 
 @pytest.fixture(scope="session")
-def _test_output_dir() -> Path:
-    TEST_OUTPUT_DIR.mkdir(exist_ok=True)
-    return TEST_OUTPUT_DIR
+def _test_output_dir(request: pytest.FixtureRequest) -> Path:
+    base = _resolve_test_output_dir(request.config)
+    base.mkdir(parents=True, exist_ok=True)
+    return base
 
 
 @pytest.fixture
@@ -196,15 +227,34 @@ def am_binaries(request: pytest.FixtureRequest) -> list[BinaryUnderTest]:
 
 
 @pytest.fixture(scope="session")
-def rawfile_tolerance(request: pytest.FixtureRequest) -> float:
-    """Rawfile byte-count tolerance: 25% in fast mode, 15% in thorough mode."""
-    return 0.25 if request.config.getoption("--mode") == "fast" else 0.15
+def mp3_tolerance(request: pytest.FixtureRequest) -> float:
+    """MP3 duration tolerance: 10% in both modes.
+
+    Fast mode (10x speedup) adds some demod-thread timing jitter — measured
+    worst-case is ~6% on multichannel non-nfm under load. 10% gives a ~1.5x
+    margin over that; tightening further risks intermittent CI failures.
+    """
+    return 0.10
 
 
 @pytest.fixture(scope="session")
-def mp3_tolerance(request: pytest.FixtureRequest) -> float:
-    """MP3 duration tolerance: 25% in fast mode, 15% in thorough mode."""
-    return 0.25 if request.config.getoption("--mode") == "fast" else 0.15
+def max_overrun_count(request: pytest.FixtureRequest) -> int:
+    """Allowed output_overrun_count threshold per mode.
+
+    Thorough mode allows 1 overrun to absorb a first-batch warm-up race:
+    on the very first batch the output thread does LAME init + file
+    create + marker-tone padding before clearing dev->waveavail, and on
+    slow hosts this can occasionally exceed the 125 ms batch period —
+    the demod thread then produces a second batch with waveavail still
+    set and increments the counter by one. Anything beyond 1 is a real
+    regression in the producer/consumer pipeline.
+
+    Fast mode (10x speedup) plus parallel pytest-xdist workers
+    contending for CPU does occasionally trip the same race by a few
+    additional batches; allow up to 5 to absorb that without losing the
+    assertion's value as a regression sentinel.
+    """
+    return 5 if request.config.getoption("--mode") == "fast" else 1
 
 
 @pytest.fixture(scope="session")

--- a/system_tests/helpers/config_writer.py
+++ b/system_tests/helpers/config_writer.py
@@ -36,10 +36,12 @@ def write_config(
             - ctcss (float|None): CTCSS tone Hz, omitted if None.
             - bandwidth (int|None): NFM demodulation bandwidth in Hz, omitted if None.
             - notch (float|None): Notch filter frequency in Hz, omitted if None.
-            - output_filename_template (str): Template for rawfile output filename.
+            - output_filename_template (str): Template for MP3 output filename
+              (used only when mp3_tmp_dir is provided).
             - mixer_output (dict|None): {"name": str, "balance": float}, omitted if None.
             - scan_freqs_hz (list[int]): Scan mode only — list of frequencies in Hz.
-        output_dir: Directory where rawfile outputs are written.
+        output_dir: Directory where mixer MP3 outputs are written. Unused when
+            mixers is empty/None.
         speedup_factor: IQ replay speed factor (1.0 = real-time).
         mode: "multichannel" or "scan".
         fft_size: FFT size for the device, omitted if None (binary default).
@@ -47,10 +49,10 @@ def write_config(
             - name (str): Mixer name referenced by channel mixer_output entries.
             - label (str): Filename template for the mixer's MP3 output.
             Output files are written to output_dir.
-        mp3_tmp_dir: If provided, each channel also gets a "file" (MP3) output
-            written to this directory using the same filename_template as the
-            rawfile. The directory must already exist. rtl_airband appends a
-            date+hour timestamp to the filename; use output_validator.validate_mp3()
+        mp3_tmp_dir: If provided, each channel gets a "file" (MP3) output
+            written to this directory using output_filename_template. The
+            directory must already exist. rtl_airband appends a date+hour
+            timestamp to the filename; use output_validator.validate_mp3()
             to find and validate the resulting file.
         stats_filepath: If provided, rtl_airband writes a Prometheus-format stats
             file to this path on shutdown.
@@ -119,13 +121,7 @@ def write_config(
 
         # Build output entries: file outputs use directory+template+append,
         # mixer outputs use name+balance.
-        output_entries: list[dict] = [
-            {
-                "type": "rawfile",
-                "directory": str(output_dir),
-                "template": ch["output_filename_template"],
-            },
-        ]
+        output_entries: list[dict] = []
         if mp3_tmp_dir is not None:
             output_entries.append(
                 {

--- a/system_tests/helpers/iq_generator.py
+++ b/system_tests/helpers/iq_generator.py
@@ -2,7 +2,13 @@
 IQ fixture generator for RTLSDR-Airband system tests.
 
 Generates U8 (unsigned 8-bit interleaved I/Q) files with known signals.
-Files are cached in .generated_input/; if a file already exists it is reused.
+Each signal-bearing fixture is wrapped in NOISE_PAD_S of low-amplitude Gaussian
+noise at the start and end so the squelch / AGC / IIR filter state has time to
+converge before the carrier appears and so the demod and output pipeline can
+drain cleanly before the input thread hits EOF.
+
+Files are cached in .generated_input/; the cache filename embeds NOISE_PAD_S so
+changing the pad invalidates old fixtures. If a file already exists it is reused.
 """
 
 from pathlib import Path
@@ -19,11 +25,21 @@ CENTERFREQ = 120_000_000  # Hz — aviation band (used in config, not physics)
 #
 # If DEFAULT_FFT_SIZE_LOG or the +20 tuning offset in ever change, update _FFT_SIZE and the
 # formula below to match — stale values will silently place the signal at the wrong bin and
-# scan tests will fail with unexpected rawfile sizes. Delete .generated_input/ after any
+# scan tests will fail with unexpected MP3 durations. Delete .generated_input/ after any
 # such change so fixtures are regenerated.
 _FFT_SIZE = 512  # 1 << DEFAULT_FFT_SIZE_LOG
 _BIN_RES_HZ = SAMPLE_RATE // _FFT_SIZE  # 4 000 Hz per bin
 SCAN_DEMOD_OFFSET_HZ = -21 * _BIN_RES_HZ  # -84 000 Hz
+
+# Leading + trailing low-amplitude noise pad on every signal fixture. The lead
+# gives the squelch noise-floor tracker, AGC `agcavgfast`, and IIR filter state
+# time to converge before the carrier arrives, so squelch open is governed by
+# the deterministic open_delay (~200 audio samples) instead of warm-up race.
+# The tail lets the squelch close on noise and the demod/output/MP3 pipeline
+# drain cleanly before the input thread hits EOF.
+NOISE_PAD_S = 1.0
+_NOISE_AMPLITUDE_U8 = np.float32(0.02 * 127.5)
+_NOISE_SEED = 42
 
 _TWO_PI = np.float32(2 * np.pi)
 _SCALE = np.float32(0.5 * 127.5)
@@ -40,6 +56,31 @@ def _quantize(signal: np.ndarray, scale: np.float32 = _SCALE) -> np.ndarray:
     return np.clip(np.round(_ORIGIN + signal * scale), 0, 255).astype(np.uint8)
 
 
+def _noise_arrays(
+    duration_s: float, rng: np.random.Generator
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate (I_u8, Q_u8) of low-amplitude Gaussian noise."""
+    n = int(SAMPLE_RATE * duration_s)
+    I = rng.standard_normal(n, dtype=np.float32) * _NOISE_AMPLITUDE_U8
+    Q = rng.standard_normal(n, dtype=np.float32) * _NOISE_AMPLITUDE_U8
+    I_u8 = np.clip(np.round(_ORIGIN + I), 0, 255).astype(np.uint8)
+    Q_u8 = np.clip(np.round(_ORIGIN + Q), 0, 255).astype(np.uint8)
+    return I_u8, Q_u8
+
+
+def _pad_with_noise(
+    I_sig: np.ndarray, Q_sig: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Prepend and append NOISE_PAD_S of noise around the signal arrays."""
+    rng = np.random.default_rng(seed=_NOISE_SEED)
+    I_lead, Q_lead = _noise_arrays(NOISE_PAD_S, rng)
+    I_tail, Q_tail = _noise_arrays(NOISE_PAD_S, rng)
+    return (
+        np.concatenate([I_lead, I_sig, I_tail]),
+        np.concatenate([Q_lead, Q_sig, Q_tail]),
+    )
+
+
 def get_or_generate_am(
     offset_hz: int,
     audio_hz: int,
@@ -50,7 +91,10 @@ def get_or_generate_am(
     Generate an AM signal at *offset_hz* from center with *audio_hz* audio tone.
     Returns path to the cached .iq file.
     """
-    filename = f"am_sr{SAMPLE_RATE}_off{offset_hz}_audio{audio_hz}_dur{duration_s}.iq"
+    filename = (
+        f"am_sr{SAMPLE_RATE}_off{offset_hz}_audio{audio_hz}"
+        f"_dur{duration_s}_pad{NOISE_PAD_S}.iq"
+    )
     path = cache_dir / filename
     if path.exists():
         return path
@@ -65,7 +109,8 @@ def get_or_generate_am(
     I = envelope * np.cos(carrier_phase)
     Q = envelope * np.sin(carrier_phase)
     del carrier_phase, envelope
-    _write_iq(path, _quantize(I), _quantize(Q))
+    I_all, Q_all = _pad_with_noise(_quantize(I), _quantize(Q))
+    _write_iq(path, I_all, Q_all)
     return path
 
 
@@ -104,7 +149,8 @@ def get_or_generate_ctcss(
     Returns path to the cached .iq file.
     """
     filename = (
-        f"ctcss_sr{SAMPLE_RATE}_off{offset_hz}_ctcss{ctcss_hz}_dur{duration_s}.iq"
+        f"ctcss_sr{SAMPLE_RATE}_off{offset_hz}_ctcss{ctcss_hz}"
+        f"_dur{duration_s}_pad{NOISE_PAD_S}.iq"
     )
     path = cache_dir / filename
     if path.exists():
@@ -122,7 +168,8 @@ def get_or_generate_ctcss(
     I = envelope * np.cos(carrier_phase)
     Q = envelope * np.sin(carrier_phase)
     del carrier_phase, envelope
-    _write_iq(path, _quantize(I), _quantize(Q))
+    I_all, Q_all = _pad_with_noise(_quantize(I), _quantize(Q))
+    _write_iq(path, I_all, Q_all)
     return path
 
 
@@ -136,7 +183,10 @@ def get_or_generate_nfm(
     Generate an NFM signal at *offset_hz* with *audio_hz* audio tone.
     Returns path to the cached .iq file.
     """
-    filename = f"nfm_sr{SAMPLE_RATE}_off{offset_hz}_audio{audio_hz}_dur{duration_s}.iq"
+    filename = (
+        f"nfm_sr{SAMPLE_RATE}_off{offset_hz}_audio{audio_hz}"
+        f"_dur{duration_s}_pad{NOISE_PAD_S}.iq"
+    )
     path = cache_dir / filename
     if path.exists():
         return path
@@ -155,7 +205,8 @@ def get_or_generate_nfm(
     I = np.cos(phase).astype(np.float32)
     Q = np.sin(phase).astype(np.float32)
     del phase
-    _write_iq(path, _quantize(I), _quantize(Q))
+    I_all, Q_all = _pad_with_noise(_quantize(I), _quantize(Q))
+    _write_iq(path, I_all, Q_all)
     return path
 
 
@@ -173,7 +224,7 @@ def get_or_generate_multichannel(
     """
     filename = (
         f"multichannel_sr{SAMPLE_RATE}_offA{offset_a_hz}_offB{offset_b_hz}"
-        f"_audio{audio_hz}_dur{duration_s}.iq"
+        f"_audio{audio_hz}_dur{duration_s}_pad{NOISE_PAD_S}.iq"
     )
     path = cache_dir / filename
     if path.exists():
@@ -191,7 +242,8 @@ def get_or_generate_multichannel(
     I = envelope * (np.cos(carrier_phase_a) + np.cos(carrier_phase_b)) * np.float32(0.5)
     Q = envelope * (np.sin(carrier_phase_a) + np.sin(carrier_phase_b)) * np.float32(0.5)
     del carrier_phase_a, carrier_phase_b, envelope
-    _write_iq(path, _quantize(I), _quantize(Q))
+    I_all, Q_all = _pad_with_noise(_quantize(I), _quantize(Q))
+    _write_iq(path, I_all, Q_all)
     return path
 
 
@@ -215,13 +267,13 @@ def get_or_generate_scan(
     """
     filename = (
         f"scan_sr{SAMPLE_RATE}_demod{SCAN_DEMOD_OFFSET_HZ}"
-        f"_durA{duration_a_s}_gap{gap_s}_durB{duration_b_s}.iq"
+        f"_durA{duration_a_s}_gap{gap_s}_durB{duration_b_s}_pad{NOISE_PAD_S}.iq"
     )
     path = cache_dir / filename
     if path.exists():
         return path
 
-    rng = np.random.default_rng(seed=42)
+    rng = np.random.default_rng(seed=_NOISE_SEED)
 
     def _am_segment(duration_s: float) -> tuple[np.ndarray, np.ndarray]:
         n = int(SAMPLE_RATE * duration_s)
@@ -236,20 +288,13 @@ def get_or_generate_scan(
         del carrier_phase, envelope
         return _quantize(I), _quantize(Q)
 
-    def _noise_segment(duration_s: float) -> tuple[np.ndarray, np.ndarray]:
-        n = int(SAMPLE_RATE * duration_s)
-        amplitude = np.float32(0.02 * 127.5)
-        I = rng.standard_normal(n, dtype=np.float32) * amplitude
-        Q = rng.standard_normal(n, dtype=np.float32) * amplitude
-        I_u8 = np.clip(np.round(_ORIGIN + I), 0, 255).astype(np.uint8)
-        Q_u8 = np.clip(np.round(_ORIGIN + Q), 0, 255).astype(np.uint8)
-        return I_u8, Q_u8
-
+    I_lead, Q_lead = _noise_arrays(NOISE_PAD_S, rng)
     I_a, Q_a = _am_segment(duration_a_s)
-    I_gap, Q_gap = _noise_segment(gap_s)
+    I_gap, Q_gap = _noise_arrays(gap_s, rng)
     I_b, Q_b = _am_segment(duration_b_s)
+    I_tail, Q_tail = _noise_arrays(NOISE_PAD_S, rng)
 
-    I_all = np.concatenate([I_a, I_gap, I_b])
-    Q_all = np.concatenate([Q_a, Q_gap, Q_b])
+    I_all = np.concatenate([I_lead, I_a, I_gap, I_b, I_tail])
+    Q_all = np.concatenate([Q_lead, Q_a, Q_gap, Q_b, Q_tail])
     _write_iq(path, I_all, Q_all)
     return path

--- a/system_tests/helpers/output_validator.py
+++ b/system_tests/helpers/output_validator.py
@@ -1,11 +1,8 @@
 """
 Output validator for RTLSDR-Airband system tests.
 
-Level 2 validation: verifies rawfile byte count against expected duration,
-and MP3 duration / audio properties against expected values.
-
-Rawfile format: interleaved float32 I/Q pairs (complex float, .cf32 extension).
-Bytes per sample pair = 2 * sizeof(float32) = 8.
+Level 2 validation: verifies MP3 duration and audio properties against
+expected values.
 
 MP3 format: LAME-encoded, mono, 8000 Hz sample rate, VBR with LAME tag.
 rtl_airband appends a date+hour timestamp to the filename_template, so MP3
@@ -19,78 +16,6 @@ from mutagen.mp3 import MP3
 
 # rtl_airband hardcodes MP3_RATE = 8000 Hz for all MP3 output
 _MP3_SAMPLE_RATE = 8000
-
-
-def validate_rawfile(
-    output_dir: Path,
-    filename_template: str,
-    expected_duration_s: float,
-    wave_rate: int,
-    tolerance: float = 0.15,
-) -> None:
-    """
-    Assert that a rawfile output has a byte count within *tolerance* of expected.
-
-    The rawfile extension is .cf32 (complex float32, interleaved I/Q pairs).
-    Each sample pair is two float32 values = 8 bytes.
-
-    Args:
-        output_dir: Directory containing the output files.
-        filename_template: Filename template used in the config (without extension).
-        expected_duration_s: Expected audio duration in seconds.
-        wave_rate: Output sample rate (8000 for non-NFM, 16000 for NFM).
-        tolerance: Allowed fractional deviation from expected byte count (default ±15%).
-
-    Raises:
-        AssertionError: If no matching file is found or byte count is out of range.
-    """
-    matches = list(output_dir.glob(f"{filename_template}_[0-9]*.cf32"))
-    assert (
-        matches
-    ), f"No .cf32 output file found matching '{filename_template}*.cf32' in {output_dir}"
-    output_file = matches[0]
-    actual_bytes = output_file.stat().st_size
-
-    # expected_bytes = duration * wave_rate * 2 (I+Q pair) * 4 bytes per float32
-    expected_bytes = expected_duration_s * wave_rate * 2 * 4
-
-    deviation = abs(actual_bytes - expected_bytes) / expected_bytes
-    print(
-        f"rawfile {output_file.name}: "
-        f"actual={actual_bytes} expected={expected_bytes:.0f} "
-        f"deviation={deviation*100:.1f}% (limit ±{tolerance*100:.0f}%)"
-    )
-    assert deviation <= tolerance, (
-        f"Rawfile byte count out of range: "
-        f"actual={actual_bytes}, expected={expected_bytes:.0f} "
-        f"(±{tolerance*100:.0f}%), deviation={deviation*100:.1f}%, "
-        f"file={output_file}"
-    )
-
-
-def assert_output_silent(output_dir: Path, filename_template: str) -> None:
-    """
-    Assert that either no .cf32 file was created matching the template, or it is empty.
-
-    This is used for squelch-closed and wrong-CTCSS tests where no audio should be written.
-
-    Args:
-        output_dir: Directory that would contain the output files.
-        filename_template: Filename template used in the config (without extension).
-
-    Raises:
-        AssertionError: If a non-empty .cf32 file is found.
-    """
-    matches = list(output_dir.glob(f"{filename_template}_[0-9]*.cf32"))
-    if not matches:
-        return  # No file created — correct for squelch-closed
-
-    for output_file in matches:
-        actual_bytes = output_file.stat().st_size
-        assert actual_bytes == 0, (
-            f"Expected no audio output (squelch/CTCSS gate closed), but "
-            f"{output_file} contains {actual_bytes} bytes"
-        )
 
 
 def validate_mp3(
@@ -160,6 +85,56 @@ def validate_mp3(
     assert deviation <= tolerance, (
         f"MP3 duration {actual_s:.2f}s deviates {deviation:.1%} from "
         f"expected {expected_duration_s:.2f}s (±{tolerance:.0%}): {label}"
+    )
+
+    return matches[0]
+
+
+def validate_mp3_range(
+    mp3_dir: Path,
+    filename_template: str,
+    min_duration_s: float,
+    max_duration_s: float,
+) -> Path:
+    """Assert an MP3 output exists with duration in [min_duration_s, max_duration_s].
+
+    Use this when the expected duration isn't a single value but a band — e.g.
+    a squelch-disabled run that always passes the signal but may also pass the
+    surrounding noise pad depending on tracker convergence.
+
+    Sample-rate and bitrate checks match validate_mp3(); only the duration
+    assertion differs.
+    """
+    matches = list(mp3_dir.glob(f"{filename_template}_[0-9]*.mp3"))
+    assert (
+        matches
+    ), f"No .mp3 output file found matching '{filename_template}_[0-9]*.mp3' in {mp3_dir}"
+
+    actual_s = 0.0
+    for mp3_file in matches:
+        assert mp3_file.stat().st_size > 0, f"MP3 file is empty: {mp3_file.name}"
+        audio = MP3(mp3_file)
+        actual_s += audio.info.length
+        assert audio.info.sample_rate == _MP3_SAMPLE_RATE, (
+            f"Expected MP3 sample rate {_MP3_SAMPLE_RATE} Hz, "
+            f"got {audio.info.sample_rate} Hz: {mp3_file.name}"
+        )
+        assert (
+            audio.info.bitrate > 0
+        ), f"MP3 average bitrate is 0 kbps (empty or corrupt file): {mp3_file.name}"
+
+    label = (
+        matches[0].name
+        if len(matches) == 1
+        else f"{len(matches)} files (hour boundary)"
+    )
+    print(
+        f"mp3 {label}: actual={actual_s:.2f}s "
+        f"expected range=[{min_duration_s:.2f}, {max_duration_s:.2f}]s"
+    )
+    assert min_duration_s <= actual_s <= max_duration_s, (
+        f"MP3 duration {actual_s:.2f}s is outside expected range "
+        f"[{min_duration_s:.2f}, {max_duration_s:.2f}]s: {label}"
     )
 
     return matches[0]

--- a/system_tests/helpers/stats_validator.py
+++ b/system_tests/helpers/stats_validator.py
@@ -50,6 +50,21 @@ class StatsFile:
         return None
 
 
+def assert_no_excessive_overruns(stats: StatsFile, max_overrun_count: int) -> None:
+    """Assert the output thread did not fall behind demod by more than max_overrun_count batches.
+
+    Thorough mode requires zero overruns; fast mode allows a small budget to
+    absorb CPU contention from -n auto. See the max_overrun_count fixture
+    in conftest.py for the rationale behind the per-mode thresholds.
+    """
+    overruns = stats.device("output_overrun_count")
+    assert overruns <= max_overrun_count, (
+        f"Output thread fell behind demod by {overruns} batches "
+        f"(allowed in this mode: <= {max_overrun_count}) — wave batches "
+        "were overwritten before being read"
+    )
+
+
 def load(path: Path) -> StatsFile:
     """
     Parse a Prometheus-format rtl_airband stats file.

--- a/system_tests/tests/test_am_squelch_closed.py
+++ b/system_tests/tests/test_am_squelch_closed.py
@@ -33,9 +33,10 @@ def pytest_generate_tests(metafunc):
 def test_am_squelch_closed(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
-    """Noise-only IQ with squelch enabled → rawfile and MP3 absent or empty."""
+    """Noise-only IQ with squelch enabled → no MP3 file (or empty file) created."""
     iq_file = iq_generator.get_or_generate_noise(
         duration_s=DURATION_S,
         cache_dir=CACHE_DIR,
@@ -66,11 +67,6 @@ def test_am_squelch_closed(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.assert_output_silent(
-        output_dir=test_output_dir,
-        filename_template=filename_template,
-    )
-
     output_validator.assert_mp3_silent(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
@@ -84,3 +80,4 @@ def test_am_squelch_closed(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)

--- a/system_tests/tests/test_am_squelch_open.py
+++ b/system_tests/tests/test_am_squelch_open.py
@@ -19,7 +19,6 @@ DURATION_S = 10.0
 # The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
 # signal, so the squelch can warm up before the carrier arrives and close
 # cleanly after it ends instead of racing input EOF.
-SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
 TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
 TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
@@ -61,8 +60,6 @@ def test_am_squelch_open(
         channels=[
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_OFFSET_HZ,
-                "squelch": SQUELCH,
-                "ctcss": None,
                 "output_filename_template": filename_template,
             }
         ],

--- a/system_tests/tests/test_am_squelch_open.py
+++ b/system_tests/tests/test_am_squelch_open.py
@@ -16,8 +16,12 @@ CENTERFREQ_HZ = 120_000_000
 CHANNEL_OFFSET_HZ = 25_000
 AUDIO_TONE_HZ = 1_000
 DURATION_S = 10.0
-SQUELCH = 0.0  # disabled — signal should always open squelch
-TIMEOUT_S = DURATION_S * 3 + 30  # 60s
+# The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
+# signal, so the squelch can warm up before the carrier arrives and close
+# cleanly after it ends instead of racing input EOF.
+SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
+TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
+TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
 
 def pytest_generate_tests(metafunc):
@@ -34,11 +38,11 @@ def pytest_generate_tests(metafunc):
 def test_am_squelch_open(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
-    rawfile_tolerance: float,
     mp3_tolerance: float,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
-    """AM signal with squelch disabled → rawfile and MP3 must contain ≈10s of audio."""
+    """AM signal opens the squelch → MP3 must contain ≈10s of audio."""
     iq_file = iq_generator.get_or_generate_am(
         offset_hz=CHANNEL_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
@@ -71,14 +75,6 @@ def test_am_squelch_open(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.validate_rawfile(
-        output_dir=test_output_dir,
-        filename_template=filename_template,
-        expected_duration_s=DURATION_S,
-        wave_rate=binary_under_test.wave_rate,
-        tolerance=rawfile_tolerance,
-    )
-
     output_validator.validate_mp3(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
@@ -90,7 +86,8 @@ def test_am_squelch_open(
     freq_hz = CENTERFREQ_HZ + CHANNEL_OFFSET_HZ
     assert (
         stats.channel("channel_activity_counter", freq_hz) > 0
-    ), "Expected non-zero activity counter for AM channel with squelch disabled"
+    ), "Expected non-zero activity counter for AM channel opening the squelch"
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)

--- a/system_tests/tests/test_ctcss.py
+++ b/system_tests/tests/test_ctcss.py
@@ -4,7 +4,7 @@ test_ctcss.py — CTCSS gate: correct tone passes, wrong tone is blocked.
 Two test functions, both parametrized over all provided binaries.
 
 test_ctcss_correct_tone: IQ with 100.0 Hz CTCSS + 1000 Hz voice, config asks for
-  100.0 Hz → output should contain audio (accounting for ~2s detection startup delay).
+  100.0 Hz → output should contain audio (accounting for CTCSS_STARTUP_DELAY_S).
 
 test_ctcss_wrong_tone: IQ with 125.0 Hz CTCSS + 1000 Hz voice, config asks for
   100.0 Hz → output should be absent or empty (gate stays closed).
@@ -23,16 +23,24 @@ SAMPLE_RATE = 2_048_000
 CENTERFREQ_HZ = 120_000_000
 CHANNEL_OFFSET_HZ = 25_000
 DURATION_S = 15.0
-SQUELCH = 0.0  # disabled — CTCSS gate is the only gate
+# The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
+# signal. Enabling squelch alongside CTCSS gives both gates time to settle on
+# noise instead of racing CTCSS startup against an always-open squelch.
+SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
 CONFIG_CTCSS_HZ = 100.0  # what the config requests
 CORRECT_CTCSS_HZ = 100.0  # matches the config → should pass
 WRONG_CTCSS_HZ = 125.0  # not a standard CTCSS tone, does not match → should block
-# The CTCSS detector needs ~2 s of tone before it opens the gate (fast detector:
-# 0.05 s windows × ~40 confirmations at 8 kHz audio rate; see ctcss.cpp).
-# Adjust this constant if the detector's startup latency changes.
-CTCSS_STARTUP_DELAY_S = 2.0
-EXPECTED_AUDIO_S = DURATION_S - CTCSS_STARTUP_DELAY_S  # 13.0 s
-TIMEOUT_S = DURATION_S * 3 + 30  # 75s
+
+# Time from carrier-on to the CTCSS gate first opening: squelch open_delay
+# (~25 ms at 8 kHz audio rate) + one fast CTCSS window (0.05 s) ≈ 75 ms.
+# 0.1 s gives a small margin for trailing-pad gate close timing.
+# squelch.cpp:118-134 — is_open() consults the fast detector until the slow one
+# has 0.4 s of samples; the fast detector checks every 0.05 s window with no
+# confirmation count requirement (ctcss.cpp:124-163).
+CTCSS_STARTUP_DELAY_S = 0.1
+EXPECTED_AUDIO_S = DURATION_S - CTCSS_STARTUP_DELAY_S  # 14.9 s
+TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 17 s
+TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 81 s
 
 
 def pytest_generate_tests(metafunc):
@@ -49,15 +57,15 @@ def pytest_generate_tests(metafunc):
 def test_ctcss_correct_tone(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
-    rawfile_tolerance: float,
     mp3_tolerance: float,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
     """
     IQ with correct CTCSS tone (100.0 Hz) → CTCSS gate opens, audio written.
 
-    Expected duration uses 13s (not 15s) to account for the ~2s CTCSS detection
-    startup delay. Tolerance is mode-dependent (15% thorough, 25% fast).
+    Expected duration is DURATION_S - CTCSS_STARTUP_DELAY_S — see the constant
+    for the CTCSS-fast-detector + squelch-open-delay derivation.
     """
     iq_file = iq_generator.get_or_generate_ctcss(
         offset_hz=CHANNEL_OFFSET_HZ,
@@ -91,14 +99,6 @@ def test_ctcss_correct_tone(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.validate_rawfile(
-        output_dir=test_output_dir,
-        filename_template=filename_template,
-        expected_duration_s=EXPECTED_AUDIO_S,
-        wave_rate=binary_under_test.wave_rate,
-        tolerance=rawfile_tolerance,
-    )
-
     output_validator.validate_mp3(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
@@ -114,11 +114,13 @@ def test_ctcss_correct_tone(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)
 
 
 def test_ctcss_wrong_tone(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
     """
@@ -157,11 +159,6 @@ def test_ctcss_wrong_tone(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.assert_output_silent(
-        output_dir=test_output_dir,
-        filename_template=filename_template,
-    )
-
     output_validator.assert_mp3_silent(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
@@ -178,3 +175,4 @@ def test_ctcss_wrong_tone(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)

--- a/system_tests/tests/test_ctcss.py
+++ b/system_tests/tests/test_ctcss.py
@@ -26,7 +26,6 @@ DURATION_S = 15.0
 # The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
 # signal. Enabling squelch alongside CTCSS gives both gates time to settle on
 # noise instead of racing CTCSS startup against an always-open squelch.
-SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
 CONFIG_CTCSS_HZ = 100.0  # what the config requests
 CORRECT_CTCSS_HZ = 100.0  # matches the config → should pass
 WRONG_CTCSS_HZ = 125.0  # not a standard CTCSS tone, does not match → should block
@@ -85,7 +84,6 @@ def test_ctcss_correct_tone(
         channels=[
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_OFFSET_HZ,
-                "squelch": SQUELCH,
                 "ctcss": CONFIG_CTCSS_HZ,
                 "output_filename_template": filename_template,
             }
@@ -145,7 +143,6 @@ def test_ctcss_wrong_tone(
         channels=[
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_OFFSET_HZ,
-                "squelch": SQUELCH,
                 "ctcss": CONFIG_CTCSS_HZ,
                 "output_filename_template": filename_template,
             }

--- a/system_tests/tests/test_multichannel.py
+++ b/system_tests/tests/test_multichannel.py
@@ -25,7 +25,6 @@ AUDIO_TONE_HZ = 1_000
 DURATION_S = 10.0
 # The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
 # signal so the squelch can warm up and close cleanly around it.
-SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
 TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
 TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
@@ -67,14 +66,10 @@ def test_multichannel(
         channels=[
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_A_OFFSET_HZ,
-                "squelch": SQUELCH,
-                "ctcss": None,
                 "output_filename_template": "ch_a",
             },
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_B_OFFSET_HZ,
-                "squelch": SQUELCH,
-                "ctcss": None,
                 "output_filename_template": "ch_b",
             },
         ],

--- a/system_tests/tests/test_multichannel.py
+++ b/system_tests/tests/test_multichannel.py
@@ -2,7 +2,7 @@
 test_multichannel.py — Two simultaneous AM channels on one device.
 
 IQ contains two AM signals at different frequency offsets. Verifies that both
-output rawfiles and MP3s contain approximately the expected amount of audio.
+output MP3s contain approximately the expected amount of audio.
 
 Parametrized over all provided binaries (non-NFM and NFM if available).
 
@@ -23,8 +23,11 @@ CHANNEL_A_OFFSET_HZ = +25_000  # 120.025 MHz
 CHANNEL_B_OFFSET_HZ = -25_000  # 119.975 MHz
 AUDIO_TONE_HZ = 1_000
 DURATION_S = 10.0
-SQUELCH = 0.0  # disabled for both channels
-TIMEOUT_S = DURATION_S * 3 + 30  # 60s
+# The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
+# signal so the squelch can warm up and close cleanly around it.
+SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
+TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
+TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
 
 def pytest_generate_tests(metafunc):
@@ -41,11 +44,11 @@ def pytest_generate_tests(metafunc):
 def test_multichannel(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
-    rawfile_tolerance: float,
     mp3_tolerance: float,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
-    """Two simultaneous AM channels → both rawfiles and MP3s must contain ≈10s of audio."""
+    """Two simultaneous AM channels → both MP3s must contain ≈10s of audio."""
     iq_file = iq_generator.get_or_generate_multichannel(
         offset_a_hz=CHANNEL_A_OFFSET_HZ,
         offset_b_hz=CHANNEL_B_OFFSET_HZ,
@@ -84,21 +87,6 @@ def test_multichannel(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.validate_rawfile(
-        output_dir=test_output_dir,
-        filename_template="ch_a",
-        expected_duration_s=DURATION_S,
-        wave_rate=binary_under_test.wave_rate,
-        tolerance=rawfile_tolerance,
-    )
-    output_validator.validate_rawfile(
-        output_dir=test_output_dir,
-        filename_template="ch_b",
-        expected_duration_s=DURATION_S,
-        wave_rate=binary_under_test.wave_rate,
-        tolerance=rawfile_tolerance,
-    )
-
     output_validator.validate_mp3(
         mp3_dir=test_output_dir,
         filename_template="ch_a",
@@ -124,3 +112,4 @@ def test_multichannel(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)

--- a/system_tests/tests/test_nfm.py
+++ b/system_tests/tests/test_nfm.py
@@ -19,7 +19,6 @@ AUDIO_TONE_HZ = 1_000
 DURATION_S = 10.0
 # The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
 # signal so the squelch can warm up and close cleanly around it.
-SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
 TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
 TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
@@ -56,8 +55,6 @@ def test_nfm(
         channels=[
             {
                 "freq_hz": CENTERFREQ_HZ + CHANNEL_OFFSET_HZ,
-                "squelch": SQUELCH,
-                "ctcss": None,
                 "output_filename_template": filename_template,
             }
         ],

--- a/system_tests/tests/test_scan.py
+++ b/system_tests/tests/test_scan.py
@@ -6,14 +6,17 @@ the signal always lands at the same fixed bin (bin 491 for fft_size=512).  With 
 file input the hardware center cannot move, so the scanner always demodulates from
 that one bin — see iq_generator.SCAN_DEMOD_OFFSET_HZ for the exact offset.
 
-The IQ fixture is a three-segment file, with BOTH signal segments placed at the
-actual demodulation bin so they are detectable regardless of which scan freq is active:
+The IQ fixture is a three-segment file wrapped in NOISE_PAD_S of leading and
+trailing noise. BOTH signal segments are placed at the actual demodulation bin
+so they are detectable regardless of which scan freq is active:
+  Lead:      noise for NOISE_PAD_S (squelch warm-up)
   Segment 1: AM at SCAN_DEMOD_OFFSET_HZ for 5s  (scanner locked on freq A)
   Segment 2: noise for 3s                         (scanner switches A → B)
   Segment 3: AM at SCAN_DEMOD_OFFSET_HZ for 5s  (scanner locked on freq B)
+  Tail:      noise for NOISE_PAD_S (clean shutdown)
 
 Config: scan mode, two configured frequencies (120.025 and 119.975 MHz).
-Expected: rawfile and MP3 total audio ≈ 10s (5s A + 5s B).
+Expected: MP3 total audio ≈ 10s (5s A + 5s B).
 
 Parametrized over all provided binaries (non-NFM and NFM if available).
 """
@@ -30,9 +33,13 @@ FREQ_B_HZ = 119_975_000  # 119.975 MHz — second scan frequency
 DURATION_A_S = 5.0
 GAP_S = 3.0  # 3s gap gives scanner plenty of time to switch (needs ~2s)
 DURATION_B_S = 5.0
-TOTAL_DURATION_S = DURATION_A_S + GAP_S + DURATION_B_S  # 13s IQ file
+# The scan fixture has NOISE_PAD_S of noise prepended and appended around the
+# A/gap/B sequence — same squelch warm-up + clean-shutdown role as other tests.
+TOTAL_IQ_DURATION_S = (
+    DURATION_A_S + GAP_S + DURATION_B_S + 2 * iq_generator.NOISE_PAD_S
+)  # 15 s
 EXPECTED_AUDIO_S = DURATION_A_S + DURATION_B_S  # ≈10s of actual signal
-TIMEOUT_S = TOTAL_DURATION_S * 3 + 30  # 69s
+TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 75 s
 
 
 def pytest_generate_tests(metafunc):
@@ -49,12 +56,12 @@ def pytest_generate_tests(metafunc):
 def test_scan(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
-    rawfile_tolerance: float,
     mp3_tolerance: float,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
     """
-    Scan mode with two frequencies → rawfile and MP3 contain ≈10s of combined audio.
+    Scan mode with two frequencies → MP3 contains ≈10s of combined audio.
     """
     iq_file = iq_generator.get_or_generate_scan(
         duration_a_s=DURATION_A_S,
@@ -89,14 +96,6 @@ def test_scan(
 
     run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.validate_rawfile(
-        output_dir=test_output_dir,
-        filename_template=filename_template,
-        expected_duration_s=EXPECTED_AUDIO_S,
-        wave_rate=binary_under_test.wave_rate,
-        tolerance=rawfile_tolerance,
-    )
-
     output_validator.validate_mp3(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
@@ -114,3 +113,4 @@ def test_scan(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)

--- a/system_tests/tests/test_squelch_disabled.py
+++ b/system_tests/tests/test_squelch_disabled.py
@@ -1,15 +1,17 @@
 """
-test_nfm.py — NFM demodulation end-to-end test.
+test_squelch_disabled.py — squelch_snr_threshold = 0 → gate is effectively always open.
 
-Uses the NFM binary only (--nfm-binary). Skipped if --nfm-binary is not provided.
-IQ: narrow FM signal at +25 kHz offset, ±3 kHz deviation, 1 kHz audio tone, 10s.
-Expected: MP3 contains ≈10s of audio.
+The IQ fixture is NOISE_PAD_S of noise + DURATION_S of strong AM signal +
+NOISE_PAD_S of noise. With the squelch disabled the signal portion always
+passes (gate opens reliably) and the noise pads may also pass depending on
+how the noise-floor tracker converges, so the MP3 duration must lie in
+[DURATION_S, TOTAL_IQ_DURATION_S]. Anything shorter than DURATION_S would
+mean the disabled-gate code path is gating off real signal — a regression.
 """
 
 from pathlib import Path
 
-import pytest
-from conftest import CACHE_DIR, run_rtl_airband
+from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -17,28 +19,30 @@ CENTERFREQ_HZ = 120_000_000
 CHANNEL_OFFSET_HZ = 25_000
 AUDIO_TONE_HZ = 1_000
 DURATION_S = 10.0
-# The IQ fixture has NOISE_PAD_S of noise prepended and appended around the
-# signal so the squelch can warm up and close cleanly around it.
-SQUELCH = 9.54  # dB SNR threshold (squelch.cpp default)
+SQUELCH = 0.0  # disabled — gate opens whenever signal >= noise floor
 TOTAL_IQ_DURATION_S = DURATION_S + 2 * iq_generator.NOISE_PAD_S  # 12 s
 TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 
 
-def test_nfm(
-    nfm_binary,
+def pytest_generate_tests(metafunc):
+    """Parametrize test_squelch_disabled over all available binaries."""
+    if "binary_under_test" in metafunc.fixturenames:
+        am_bins: list[BinaryUnderTest] = metafunc.config._rtlsdr_am_binaries
+        metafunc.parametrize(
+            "binary_under_test",
+            am_bins,
+            ids=[b.label for b in am_bins],
+        )
+
+
+def test_squelch_disabled(
+    binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
-    mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
-    """
-    NFM demodulation: narrow FM signal → MP3 must contain ≈10s of audio.
-    Skipped if --nfm-binary is not provided.
-    """
-    if nfm_binary is None:
-        pytest.skip("No NFM binary provided via --nfm-binary")
-
-    iq_file = iq_generator.get_or_generate_nfm(
+    """AM signal + squelch_snr_threshold=0 → MP3 produced, channel sees activity."""
+    iq_file = iq_generator.get_or_generate_am(
         offset_hz=CHANNEL_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
         duration_s=DURATION_S,
@@ -46,7 +50,7 @@ def test_nfm(
     )
 
     config_path = test_output_dir / "rtl_airband.conf"
-    filename_template = "nfm_out"
+    filename_template = "squelch_disabled"
 
     config_writer.write_config(
         config_path=config_path,
@@ -68,20 +72,20 @@ def test_nfm(
         stats_filepath=test_output_dir / "stats.txt",
     )
 
-    run_rtl_airband(nfm_binary, config_path, timeout_s=TIMEOUT_S)
+    run_rtl_airband(binary_under_test.path, config_path, timeout_s=TIMEOUT_S)
 
-    output_validator.validate_mp3(
+    output_validator.validate_mp3_range(
         mp3_dir=test_output_dir,
         filename_template=filename_template,
-        expected_duration_s=DURATION_S,
-        tolerance=mp3_tolerance,
+        min_duration_s=DURATION_S,
+        max_duration_s=TOTAL_IQ_DURATION_S,
     )
 
     stats = stats_validator.load(test_output_dir / "stats.txt")
     freq_hz = CENTERFREQ_HZ + CHANNEL_OFFSET_HZ
     assert (
         stats.channel("channel_activity_counter", freq_hz) > 0
-    ), "Expected non-zero activity counter for NFM channel"
+    ), "Expected non-zero activity counter with squelch disabled"
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Unexpected device buffer overflow"

--- a/system_tests/tests/test_user_provided.py
+++ b/system_tests/tests/test_user_provided.py
@@ -88,8 +88,8 @@ def test_user_provided(
     test_case: UserTestCase | None,
     request: pytest.FixtureRequest,
     test_output_dir: Path,
-    rawfile_tolerance: float,
     mp3_tolerance: float,
+    max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
     """
@@ -110,10 +110,8 @@ def test_user_provided(
         if binary_path_str is None:
             pytest.skip("NFM binary not provided via --nfm-binary")
         binary_path = Path(binary_path_str).resolve()
-        wave_rate = 16_000
     else:  # "non-nfm"
         binary_path = Path(request.config.getoption("--binary")).resolve()
-        wave_rate = 8_000
 
     # Check IQ file exists
     iq_file = test_case.iq_file
@@ -185,16 +183,9 @@ def test_user_provided(
                 filename_template=mx.label,
             )
 
-    # Validate each channel — rawfile and MP3
+    # Validate each channel — MP3 only
     for ch in test_case.channels:
         if ch.expected_audio_s > 0:
-            output_validator.validate_rawfile(
-                output_dir=test_output_dir,
-                filename_template=ch.label,
-                expected_duration_s=ch.expected_audio_s,
-                wave_rate=wave_rate,
-                tolerance=rawfile_tolerance,
-            )
             output_validator.validate_mp3(
                 mp3_dir=test_output_dir,
                 filename_template=ch.label,
@@ -202,10 +193,6 @@ def test_user_provided(
                 tolerance=mp3_tolerance,
             )
         else:
-            output_validator.assert_output_silent(
-                output_dir=test_output_dir,
-                filename_template=ch.label,
-            )
             output_validator.assert_mp3_silent(
                 mp3_dir=test_output_dir,
                 filename_template=ch.label,
@@ -216,6 +203,7 @@ def test_user_provided(
     assert (
         stats.device("buffer_overflow_count") == 0
     ), "Device buffer overflowed — increase speedup_factor or reduce channel count"
+    stats_validator.assert_no_excessive_overruns(stats, max_overrun_count)
     for ch in test_case.channels:
         if ch.expected_audio_s > 0:
             assert (


### PR DESCRIPTION
bugs:
 - "lost" wakeup race in the Signal class
 - reset MP3 frame counter when closing file

system tests:
 - use tmpdir for runners
 - drop raw file
 - add noise padding in generated files
 - check overrun counts
 - fix CTCSS delay calculation
 - use default squelch / test disabled squelch

I am making my contributions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties.