### PR TITLE
system_tests updates

### DIFF
--- a/.github/workflows/platform_build.yml
+++ b/.github/workflows/platform_build.yml
@@ -18,17 +18,23 @@ jobs:
             platform: rpiv2
             sudo: true
             uv_cmd: ~/.local/bin/uv
-            test_output_dir: /test_data
+            test_output_dir: /test_data/test_output
+            generated_input_dir: /test_data/generated_input
+            generated_input_max_bytes: 70M
           - runner: pi_4b
             platform: native
             sudo: false
             uv_cmd: ~/.local/bin/uv
-            test_output_dir: /test_data
+            test_output_dir: /test_data/test_output
+            generated_input_dir: /test_data/generated_input
+            generated_input_max_bytes: 70M
           - runner: ubuntu-22.04-arm
             platform: native
             sudo: false
             uv_cmd: uv
             test_output_dir: ''
+            generated_input_dir: ''
+            generated_input_max_bytes: ''
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
@@ -60,11 +66,15 @@ jobs:
       env:
         SUDO_FLAG: ${{ matrix.sudo == true && '--sudo' || '' }}
         TEST_OUTPUT_DIR: ${{ matrix.test_output_dir }}
+        GENERATED_INPUT_DIR: ${{ matrix.generated_input_dir }}
+        GENERATED_INPUT_MAX_BYTES: ${{ matrix.generated_input_max_bytes }}
       run: |
         ${{ matrix.uv_cmd }} run --no-group dev pytest system_tests/tests/ \
           --binary builds/Release/src/rtl_airband \
           $SUDO_FLAG \
           ${TEST_OUTPUT_DIR:+--test-output-dir=$TEST_OUTPUT_DIR} \
+          ${GENERATED_INPUT_DIR:+--generated-input-dir=$GENERATED_INPUT_DIR} \
+          ${GENERATED_INPUT_MAX_BYTES:+--generated-input-max-bytes=$GENERATED_INPUT_MAX_BYTES} \
           --mode thorough \
           --clean \
           -v

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -17,6 +17,8 @@ IQ fixtures are cached in `.generated_input/` and reused across runs. Test outpu
 > rm -rf system_tests/.generated_input/
 > ```
 
+The full fixture set is a few hundred MB. On a space-constrained host you can cap the cache with `--generated-input-max-bytes` (see [Cache size limit](#cache-size-limit) below).
+
 ## Prerequisites
 
 - [uv](https://docs.astral.sh/uv/) — Python package manager
@@ -66,7 +68,37 @@ uv run pytest tests/ --binary ../builds/Release/src/rtl_airband --test-output-di
 
 The `--test-output-dir` path must exist and be writable by the test process. The cleanup logic in `conftest.py` only wipes the *contents* of the directory, never the directory itself, so it is safe to point at a pre-mounted tmpfs.
 
-The CI runner is provisioned with a `/test_data` tmpfs mount; the workflow at `.github/workflows/platform_build.yml` uses it via `--test-output-dir=/test_data`. The `ubuntu-22.04-arm` runner has fast enough storage that it stays on the default path.
+### Cache directory
+
+By default IQ fixtures are cached under `system_tests/.generated_input/`. Override with `--generated-input-dir` to point the cache at a tmpfs, which keeps fixture reads/writes off slow or wear-sensitive storage (e.g. the Pi runners' SD cards):
+
+```bash
+uv run pytest tests/ --binary ../builds/Release/src/rtl_airband --generated-input-dir=/test_data/generated_input
+```
+
+Like `--test-output-dir`, `--clean` only wipes the *contents* of this directory, so it is safe to point at a pre-mounted tmpfs subdirectory. Keep it a **sibling** of the output directory (not a parent/child), so the two cleanups don't interfere.
+
+### Cache size limit
+
+The cache holds every distinct IQ fixture generated during a run (a few hundred MB in total). By default it is unbounded. On a host with limited disk — or when the cache lives on a small tmpfs — cap it with `--generated-input-max-bytes`:
+
+```bash
+uv run pytest tests/ --binary ../builds/Release/src/rtl_airband --generated-input-max-bytes=90M
+```
+
+The value accepts a `K`/`M`/`G` suffix or a plain byte count. When set, the least-recently-used fixtures are evicted before a new one is written, so the on-disk total stays within budget. Fixtures reused within a run (e.g. across the non-nfm/nfm parametrization) stay warm and are not regenerated. A single fixture larger than the whole budget is still written. Tests run serially in `--mode thorough`, so the working set is small: the peak is one fixture at a time (the largest is ~66 MiB), which comfortably fits a budget below the total cache size.
+
+### CI tmpfs layout
+
+The Pi CI runners are provisioned with a 100 MB `/test_data` tmpfs mount. `.github/workflows/platform_build.yml` puts both the cache and the output on it, in sibling subdirectories, and caps the cache so both fit:
+
+```
+--test-output-dir=/test_data/test_output
+--generated-input-dir=/test_data/generated_input
+--generated-input-max-bytes=70M
+```
+
+This keeps all fixture and output I/O off the SD card. The `ubuntu-22.04-arm` runner has fast enough storage that it stays on the default (unbounded, on-disk) paths.
 
 ## Test Coverage
 

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -13,9 +13,50 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from helpers import iq_generator
 
-CACHE_DIR = Path(__file__).parent / ".generated_input"
+DEFAULT_CACHE_DIR = Path(__file__).parent / ".generated_input"
 DEFAULT_TEST_OUTPUT_DIR = Path(__file__).parent / "test_output"
+
+_SIZE_SUFFIXES = {"K": 1024, "M": 1024**2, "G": 1024**3}
+
+
+def parse_size(value: str | None) -> int | None:
+    """Parse a byte-size string into an int; None/empty means unlimited.
+
+    Accepts a plain byte count ("94371840") or a K/M/G suffix ("90M", "1.5G").
+    Raises ValueError on a malformed value.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    mult = 1
+    if s[-1].upper() in _SIZE_SUFFIXES:
+        mult = _SIZE_SUFFIXES[s[-1].upper()]
+        s = s[:-1]
+    try:
+        n = int(float(s) * mult)
+    except ValueError as exc:
+        raise ValueError(f"invalid size {value!r}") from exc
+    if n < 0:
+        raise ValueError(f"size must be non-negative, got {value!r}")
+    return n
+
+
+def _resolve_cache_dir(config: pytest.Config) -> Path:
+    """Return the IQ-fixture cache directory.
+
+    Defaults to system_tests/.generated_input; can be overridden with
+    --generated-input-dir, useful for pointing the cache at a tmpfs to avoid
+    SD-card wear on hosts like the Pi CI runners.
+    """
+    try:
+        override = config.getoption("--generated-input-dir")
+    except ValueError:
+        override = None
+    return Path(override) if override else DEFAULT_CACHE_DIR
 
 
 def _resolve_test_output_dir(config: pytest.Config) -> Path:
@@ -72,6 +113,25 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Delete the .generated_input cache before running tests",
     )
     parser.addoption(
+        "--generated-input-dir",
+        default=None,
+        help=(
+            "Override the directory used to cache generated IQ fixtures "
+            "(default: system_tests/.generated_input). Point this at a tmpfs to "
+            "keep fixture reads/writes off slow or wear-sensitive storage."
+        ),
+    )
+    parser.addoption(
+        "--generated-input-max-bytes",
+        default=None,
+        help=(
+            "Cap the .generated_input cache at this size (e.g. 90M, 1.5G, or a "
+            "plain byte count). Least-recently-used fixtures are evicted before "
+            "a new one is written. Default: unlimited (no eviction). Useful when "
+            "the cache lives on a small tmpfs."
+        ),
+    )
+    parser.addoption(
         "--test-output-dir",
         default=None,
         help=(
@@ -113,10 +173,27 @@ def pytest_configure(config: pytest.Config) -> None:
         pass
 
     try:
-        if config.getoption("--clean") and CACHE_DIR.exists():
-            shutil.rmtree(CACHE_DIR)
+        if config.getoption("--clean"):
+            cache_dir = _resolve_cache_dir(config)
+            if cache_dir.exists():
+                # Wipe contents, not the dir itself — it may be a tmpfs mount
+                # point (e.g. a subdir of /test_data) we shouldn't unlink.
+                for child in cache_dir.iterdir():
+                    if child.is_dir():
+                        shutil.rmtree(child)
+                    else:
+                        child.unlink()
     except ValueError:
         pass
+
+    try:
+        raw_budget = config.getoption("--generated-input-max-bytes")
+    except ValueError:
+        raw_budget = None  # option not registered yet (e.g. plugin loading)
+    try:
+        iq_generator.set_cache_budget(parse_size(raw_budget))
+    except ValueError as exc:
+        pytest.exit(f"ERROR: {exc}", returncode=4)
 
     test_output_base = _resolve_test_output_dir(config)
     if test_output_base.exists():
@@ -196,9 +273,12 @@ def nfm_binary(request: pytest.FixtureRequest) -> Path | None:
     return p
 
 
-@pytest.fixture(scope="session", autouse=True)
-def ensure_cache_dir() -> None:
-    CACHE_DIR.mkdir(exist_ok=True)
+@pytest.fixture(scope="session")
+def cache_dir(request: pytest.FixtureRequest) -> Path:
+    """IQ-fixture cache directory (overridable via --generated-input-dir)."""
+    d = _resolve_cache_dir(request.config)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 @pytest.fixture(scope="session")

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -45,6 +45,34 @@ def parse_size(value: str | None) -> int | None:
     return n
 
 
+def _wipe_dir_contents(path: Path) -> None:
+    """Delete everything inside *path*, leaving the directory itself in place.
+
+    The dir may be a tmpfs mount point (e.g. a subdir of /test_data) we must
+    not unlink.
+    """
+    if not path.exists():
+        return
+    for child in path.iterdir():
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def _is_xdist_controller(config: pytest.Config) -> bool:
+    """True on the controlling process (or a non-xdist run), False on a worker.
+
+    pytest-xdist sets `config.workerinput` only on worker processes. Session-wide
+    destructive setup (wiping the shared test-output and cache dirs) must run
+    exactly once, on the controller, before workers boot — never from each
+    worker. Otherwise a late-starting worker's wipe deletes a live test's output
+    dir mid-run (staggered worker startup spans ~1s under load, longer than a
+    fast-mode test), causing intermittent "stats file not found" failures.
+    """
+    return not hasattr(config, "workerinput")
+
+
 def _resolve_cache_dir(config: pytest.Config) -> Path:
     """Return the IQ-fixture cache directory.
 
@@ -172,17 +200,13 @@ def pytest_configure(config: pytest.Config) -> None:
     except ValueError:
         pass
 
+    # Session-wide destructive cleanup runs once on the controller, before
+    # xdist workers boot — never per-worker (see _is_xdist_controller).
+    is_controller = _is_xdist_controller(config)
+
     try:
-        if config.getoption("--clean"):
-            cache_dir = _resolve_cache_dir(config)
-            if cache_dir.exists():
-                # Wipe contents, not the dir itself — it may be a tmpfs mount
-                # point (e.g. a subdir of /test_data) we shouldn't unlink.
-                for child in cache_dir.iterdir():
-                    if child.is_dir():
-                        shutil.rmtree(child)
-                    else:
-                        child.unlink()
+        if is_controller and config.getoption("--clean"):
+            _wipe_dir_contents(_resolve_cache_dir(config))
     except ValueError:
         pass
 
@@ -191,19 +215,13 @@ def pytest_configure(config: pytest.Config) -> None:
     except ValueError:
         raw_budget = None  # option not registered yet (e.g. plugin loading)
     try:
-        iq_generator.set_cache_budget(parse_size(raw_budget))
+        cache_budget = parse_size(raw_budget)
     except ValueError as exc:
         pytest.exit(f"ERROR: {exc}", returncode=4)
+    iq_generator.set_cache_budget(cache_budget)
 
-    test_output_base = _resolve_test_output_dir(config)
-    if test_output_base.exists():
-        # Clean only contents, not the directory itself — the caller may have
-        # set up the path as a mount point (e.g. tmpfs) we shouldn't unlink.
-        for child in test_output_base.iterdir():
-            if child.is_dir():
-                shutil.rmtree(child)
-            else:
-                child.unlink()
+    if is_controller:
+        _wipe_dir_contents(_resolve_test_output_dir(config))
 
     binary_val = None
     nfm_val = None
@@ -247,6 +265,16 @@ def pytest_configure(config: pytest.Config) -> None:
             "ERROR: --mode thorough is incompatible with -n / --numprocesses. "
             "Thorough mode runs serially so the tight overrun budget stays "
             "meaningful. Use --mode fast for parallel runs.",
+            returncode=4,
+        )
+
+    if cache_budget is not None and numprocesses not in (None, 0, "0"):
+        pytest.exit(
+            "ERROR: --generated-input-max-bytes is incompatible with -n / "
+            "--numprocesses. The LRU budget is per-process module state; under "
+            "xdist, workers would enforce independent budgets over a shared "
+            "cache dir and could unlink a fixture another worker is reading. "
+            "Run serially, or drop the budget for parallel runs.",
             returncode=4,
         )
 

--- a/system_tests/helpers/iq_generator.py
+++ b/system_tests/helpers/iq_generator.py
@@ -17,6 +17,7 @@ within budget — useful when the cache lives on a small tmpfs. Default is
 unlimited (no eviction).
 """
 
+import os
 from collections import OrderedDict
 from pathlib import Path
 
@@ -62,10 +63,8 @@ _ORIGIN = np.float32(128)
 # budget. Recency is tracked in _lru (insertion order = LRU..MRU); a cache hit
 # or a fresh write marks that file most-recently-used via _touch().
 #
-# These are process-global and reset per session by set_cache_budget(). The
-# accounting assumes a single generator thread (tests run serially in
-# --mode thorough); under pytest-xdist, workers would share the cache dir with
-# independent per-process budgets and could collectively exceed it.
+# State is process-global and reset per session by set_cache_budget(). A budget
+# assumes a single generator process; conftest rejects a budget under xdist.
 # ---------------------------------------------------------------------------
 
 _cache_max_bytes: int | None = None
@@ -134,6 +133,8 @@ def _evict_for(cache_dir: Path, incoming_bytes: int, protect_name: str) -> None:
         if total + incoming_bytes <= _cache_max_bytes:
             break
         if name == protect_name:
+            # Defensive: callers only write not-yet-existing files, so the
+            # incoming name is never seeded into _lru — this branch never fires.
             continue
         victim = cache_dir / name
         if victim.exists():
@@ -143,11 +144,19 @@ def _evict_for(cache_dir: Path, incoming_bytes: int, protect_name: str) -> None:
 
 
 def _write_iq(path: Path, I_u8: np.ndarray, Q_u8: np.ndarray) -> None:
-    """Interleave I/Q arrays and write as raw bytes, honoring the cache budget."""
+    """Interleave I/Q arrays and write as raw bytes, honoring the cache budget.
+
+    The write is atomic (temp file + os.replace) so a concurrent reader — e.g.
+    another xdist worker whose rtl_airband is opening this same shared fixture —
+    never sees a partially written file. The temp name avoids the *.iq glob so
+    it isn't counted toward the budget or picked up as a fixture.
+    """
     iq = np.column_stack([I_u8, Q_u8]).flatten()
     data = iq.tobytes()
     _evict_for(path.parent, len(data), path.name)
-    path.write_bytes(data)
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
     _touch(path)
 
 

--- a/system_tests/helpers/iq_generator.py
+++ b/system_tests/helpers/iq_generator.py
@@ -9,8 +9,15 @@ drain cleanly before the input thread hits EOF.
 
 Files are cached in .generated_input/; the cache filename embeds NOISE_PAD_S so
 changing the pad invalidates old fixtures. If a file already exists it is reused.
+
+The cache can be bounded to a byte budget via set_cache_budget() (wired to the
+--generated-input-max-bytes CLI option). When set, the least-recently-used
+fixtures are evicted before a new one is written so the on-disk total stays
+within budget — useful when the cache lives on a small tmpfs. Default is
+unlimited (no eviction).
 """
 
+from collections import OrderedDict
 from pathlib import Path
 
 import numpy as np
@@ -46,10 +53,102 @@ _SCALE = np.float32(0.5 * 127.5)
 _ORIGIN = np.float32(128)
 
 
+# ---------------------------------------------------------------------------
+# LRU cache budget
+#
+# When _cache_max_bytes is None the cache is unlimited and nothing is ever
+# evicted (original behavior). When set, _evict_for() removes least-recently-
+# used fixtures before a new one is written so the on-disk total stays within
+# budget. Recency is tracked in _lru (insertion order = LRU..MRU); a cache hit
+# or a fresh write marks that file most-recently-used via _touch().
+#
+# These are process-global and reset per session by set_cache_budget(). The
+# accounting assumes a single generator thread (tests run serially in
+# --mode thorough); under pytest-xdist, workers would share the cache dir with
+# independent per-process budgets and could collectively exceed it.
+# ---------------------------------------------------------------------------
+
+_cache_max_bytes: int | None = None
+_lru: "OrderedDict[str, None]" = OrderedDict()
+_seeded_dirs: set[Path] = set()
+
+
+def set_cache_budget(max_bytes: int | None) -> None:
+    """Set the cache byte budget (None = unlimited) and reset recency tracking."""
+    global _cache_max_bytes  # pylint: disable=global-statement
+    _cache_max_bytes = max_bytes
+    _lru.clear()
+    _seeded_dirs.clear()
+
+
+def _touch(path: Path) -> None:
+    """Mark *path* most-recently-used.
+
+    Seeds pre-existing on-disk fixtures first (when a budget is active) so a
+    cache hit before the session's first write can't jump ahead of older files
+    in the LRU order.
+    """
+    if _cache_max_bytes is not None:
+        _seed(path.parent)
+    _lru.pop(path.name, None)
+    _lru[path.name] = None
+
+
+def _register_hit(path: Path) -> Path:
+    """Record a cache hit and return the path (keeps reused fixtures warm)."""
+    _touch(path)
+    return path
+
+
+def _seed(cache_dir: Path) -> None:
+    """Populate the LRU from fixtures already on disk, oldest first.
+
+    Runs once per directory so eviction works even without a --clean run that
+    starts from an empty cache. Ordered by mtime so pre-existing files evict
+    oldest-first.
+    """
+    if cache_dir in _seeded_dirs:
+        return
+    _seeded_dirs.add(cache_dir)
+    existing = [f for f in cache_dir.glob("*.iq") if f.is_file()]
+    for f in sorted(existing, key=lambda p: p.stat().st_mtime):
+        if f.name not in _lru:
+            _lru[f.name] = None
+
+
+def _current_bytes(cache_dir: Path) -> int:
+    return sum(f.stat().st_size for f in cache_dir.glob("*.iq") if f.is_file())
+
+
+def _evict_for(cache_dir: Path, incoming_bytes: int, protect_name: str) -> None:
+    """Evict LRU fixtures until *incoming_bytes* fits within the budget.
+
+    A file larger than the whole budget is still written (after evicting
+    everything else) — the current fixture is always needed.
+    """
+    if _cache_max_bytes is None:
+        return
+    _seed(cache_dir)
+    total = _current_bytes(cache_dir)
+    for name in list(_lru.keys()):
+        if total + incoming_bytes <= _cache_max_bytes:
+            break
+        if name == protect_name:
+            continue
+        victim = cache_dir / name
+        if victim.exists():
+            total -= victim.stat().st_size
+            victim.unlink()
+        _lru.pop(name, None)
+
+
 def _write_iq(path: Path, I_u8: np.ndarray, Q_u8: np.ndarray) -> None:
-    """Interleave I/Q arrays and write as raw bytes."""
+    """Interleave I/Q arrays and write as raw bytes, honoring the cache budget."""
     iq = np.column_stack([I_u8, Q_u8]).flatten()
-    path.write_bytes(iq.tobytes())
+    data = iq.tobytes()
+    _evict_for(path.parent, len(data), path.name)
+    path.write_bytes(data)
+    _touch(path)
 
 
 def _quantize(signal: np.ndarray, scale: np.float32 = _SCALE) -> np.ndarray:
@@ -97,7 +196,7 @@ def get_or_generate_am(
     )
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     num_samples = int(SAMPLE_RATE * duration_s)
     t = np.linspace(0, duration_s, num_samples, dtype=np.float32, endpoint=False)
@@ -125,7 +224,7 @@ def get_or_generate_noise(
     filename = f"noise_sr{SAMPLE_RATE}_dur{duration_s}.iq"
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     num_samples = int(SAMPLE_RATE * duration_s)
     rng = np.random.default_rng(seed=42)
@@ -154,7 +253,7 @@ def get_or_generate_ctcss(
     )
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     num_samples = int(SAMPLE_RATE * duration_s)
     t = np.linspace(0, duration_s, num_samples, dtype=np.float32, endpoint=False)
@@ -189,7 +288,7 @@ def get_or_generate_nfm(
     )
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     deviation = 3000  # Hz, narrow FM ±3 kHz
     num_samples = int(SAMPLE_RATE * duration_s)
@@ -228,7 +327,7 @@ def get_or_generate_multichannel(
     )
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     num_samples = int(SAMPLE_RATE * duration_s)
     t = np.linspace(0, duration_s, num_samples, dtype=np.float32, endpoint=False)
@@ -271,7 +370,7 @@ def get_or_generate_scan(
     )
     path = cache_dir / filename
     if path.exists():
-        return path
+        return _register_hit(path)
 
     rng = np.random.default_rng(seed=_NOISE_SEED)
 

--- a/system_tests/tests/test_am_squelch_closed.py
+++ b/system_tests/tests/test_am_squelch_closed.py
@@ -8,7 +8,7 @@ test_am_squelch_closed[nfm].
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -33,13 +33,14 @@ def pytest_generate_tests(metafunc):
 def test_am_squelch_closed(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
     """Noise-only IQ with squelch enabled → no MP3 file (or empty file) created."""
     iq_file = iq_generator.get_or_generate_noise(
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_am_squelch_open.py
+++ b/system_tests/tests/test_am_squelch_open.py
@@ -8,7 +8,7 @@ test_am_squelch_open[nfm].
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -37,6 +37,7 @@ def pytest_generate_tests(metafunc):
 def test_am_squelch_open(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
@@ -46,7 +47,7 @@ def test_am_squelch_open(
         offset_hz=CHANNEL_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_ctcss.py
+++ b/system_tests/tests/test_ctcss.py
@@ -16,7 +16,7 @@ bin (k=6) in both the fast (0.05s) and slow (0.4s) CTCSS detectors at 8 kHz and
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -56,6 +56,7 @@ def pytest_generate_tests(metafunc):
 def test_ctcss_correct_tone(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
@@ -70,7 +71,7 @@ def test_ctcss_correct_tone(
         offset_hz=CHANNEL_OFFSET_HZ,
         ctcss_hz=CORRECT_CTCSS_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"
@@ -118,6 +119,7 @@ def test_ctcss_correct_tone(
 def test_ctcss_wrong_tone(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
@@ -129,7 +131,7 @@ def test_ctcss_wrong_tone(
         offset_hz=CHANNEL_OFFSET_HZ,
         ctcss_hz=WRONG_CTCSS_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_iq_cache.py
+++ b/system_tests/tests/test_iq_cache.py
@@ -1,6 +1,7 @@
 """
 test_iq_cache.py — unit tests for the LRU byte-budget cache in iq_generator
-and the --generated-input-max-bytes size parser in conftest.
+and the cache/output helpers in conftest (size parser, dir resolution, the
+xdist-controller guard, and the directory-wipe helper).
 
 These exercise pure helper logic and do not run the rtl_airband binary.
 """
@@ -10,15 +11,29 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from conftest import DEFAULT_CACHE_DIR, _resolve_cache_dir, parse_size
+from conftest import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_TEST_OUTPUT_DIR,
+    _is_xdist_controller,
+    _resolve_cache_dir,
+    _resolve_test_output_dir,
+    _wipe_dir_contents,
+    parse_size,
+)
 from helpers import iq_generator
 
 
 class _FakeConfig:  # pylint: disable=too-few-public-methods
-    """Minimal pytest.Config stand-in for testing option resolvers."""
+    """Minimal pytest.Config stand-in for testing option resolvers.
 
-    def __init__(self, options: dict):
+    workerinput is set only when provided, mirroring pytest-xdist (the attribute
+    exists on workers, is absent on the controller).
+    """
+
+    def __init__(self, options: dict, workerinput: dict | None = None):
         self._options = options
+        if workerinput is not None:
+            self.workerinput = workerinput
 
     def getoption(self, name: str):
         if name in self._options:
@@ -84,7 +99,7 @@ def test_parse_size_valid(value, expected):
     assert parse_size(value) == expected
 
 
-@pytest.mark.parametrize("value", ["abc", "10X", "1.2.3", "-5", "-1M"])
+@pytest.mark.parametrize("value", ["abc", "10X", "1.2.3", "-5", "-1M", "K", "M"])
 def test_parse_size_invalid(value):
     with pytest.raises(ValueError):
         parse_size(value)
@@ -108,6 +123,49 @@ def test_resolve_cache_dir_override(tmp_path):
 def test_resolve_cache_dir_option_absent():
     # Option not registered (e.g. plugin loading) → fall back to default.
     assert _resolve_cache_dir(_FakeConfig({})) == DEFAULT_CACHE_DIR
+
+
+def test_resolve_test_output_dir_default():
+    cfg = _FakeConfig({"--test-output-dir": None})
+    assert _resolve_test_output_dir(cfg) == DEFAULT_TEST_OUTPUT_DIR
+
+
+def test_resolve_test_output_dir_override(tmp_path):
+    cfg = _FakeConfig({"--test-output-dir": str(tmp_path)})
+    assert _resolve_test_output_dir(cfg) == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# xdist controller guard + directory wipe
+# ---------------------------------------------------------------------------
+
+
+def test_is_xdist_controller_when_no_workerinput():
+    # No workerinput attr → controller (or a non-xdist run).
+    assert _is_xdist_controller(_FakeConfig({})) is True
+
+
+def test_is_xdist_controller_false_on_worker():
+    cfg = _FakeConfig({}, workerinput={"workerid": "gw3"})  # xdist sets this on workers
+    assert _is_xdist_controller(cfg) is False
+
+
+def test_wipe_dir_contents_removes_children_keeps_dir(tmp_path):
+    (tmp_path / "a.txt").write_text("x")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("y")
+
+    _wipe_dir_contents(tmp_path)
+
+    assert tmp_path.exists()  # dir itself preserved (may be a mount point)
+    assert not list(tmp_path.iterdir())
+
+
+def test_wipe_dir_contents_noop_on_missing_dir(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    _wipe_dir_contents(missing)  # must not raise
+    assert not missing.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/system_tests/tests/test_iq_cache.py
+++ b/system_tests/tests/test_iq_cache.py
@@ -1,0 +1,201 @@
+"""
+test_iq_cache.py — unit tests for the LRU byte-budget cache in iq_generator
+and the --generated-input-max-bytes size parser in conftest.
+
+These exercise pure helper logic and do not run the rtl_airband binary.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from conftest import DEFAULT_CACHE_DIR, _resolve_cache_dir, parse_size
+from helpers import iq_generator
+
+
+class _FakeConfig:  # pylint: disable=too-few-public-methods
+    """Minimal pytest.Config stand-in for testing option resolvers."""
+
+    def __init__(self, options: dict):
+        self._options = options
+
+    def getoption(self, name: str):
+        if name in self._options:
+            return self._options[name]
+        raise ValueError(f"unknown option {name}")
+
+
+def _write(cache_dir: Path, name: str, nbytes: int) -> Path:
+    """Write an .iq fixture of exactly nbytes through the budgeted writer."""
+    assert nbytes % 2 == 0, "iq files are 2 bytes per sample"
+    n = nbytes // 2
+    path = cache_dir / name
+    iq_generator._write_iq(path, np.zeros(n, np.uint8), np.zeros(n, np.uint8))
+    return path
+
+
+def _total(cache_dir: Path) -> int:
+    return sum(f.stat().st_size for f in cache_dir.glob("*.iq"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_state():
+    """Give each test a clean cache state, then restore the session's.
+
+    iq_generator holds the budget and LRU as module globals. These tests mutate
+    them, so we snapshot on entry and restore on exit — otherwise this module
+    would clobber the session-wide budget that pytest_configure set for the
+    real system tests that sort after it.
+    """
+    saved_budget = iq_generator._cache_max_bytes
+    saved_lru = iq_generator._lru.copy()
+    saved_seeded = set(iq_generator._seeded_dirs)
+    iq_generator.set_cache_budget(None)
+    yield
+    iq_generator._cache_max_bytes = saved_budget
+    iq_generator._lru.clear()
+    iq_generator._lru.update(saved_lru)
+    iq_generator._seeded_dirs.clear()
+    iq_generator._seeded_dirs.update(saved_seeded)
+
+
+# ---------------------------------------------------------------------------
+# parse_size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        ("", None),
+        ("  ", None),
+        ("100", 100),
+        ("1K", 1024),
+        ("2M", 2 * 1024**2),
+        ("1G", 1024**3),
+        ("1.5G", int(1.5 * 1024**3)),
+        ("90m", 90 * 1024**2),  # suffix is case-insensitive
+        ("0", 0),
+    ],
+)
+def test_parse_size_valid(value, expected):
+    assert parse_size(value) == expected
+
+
+@pytest.mark.parametrize("value", ["abc", "10X", "1.2.3", "-5", "-1M"])
+def test_parse_size_invalid(value):
+    with pytest.raises(ValueError):
+        parse_size(value)
+
+
+# ---------------------------------------------------------------------------
+# cache dir resolution (--generated-input-dir)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_cache_dir_default():
+    cfg = _FakeConfig({"--generated-input-dir": None})
+    assert _resolve_cache_dir(cfg) == DEFAULT_CACHE_DIR
+
+
+def test_resolve_cache_dir_override(tmp_path):
+    cfg = _FakeConfig({"--generated-input-dir": str(tmp_path)})
+    assert _resolve_cache_dir(cfg) == tmp_path
+
+
+def test_resolve_cache_dir_option_absent():
+    # Option not registered (e.g. plugin loading) → fall back to default.
+    assert _resolve_cache_dir(_FakeConfig({})) == DEFAULT_CACHE_DIR
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction
+# ---------------------------------------------------------------------------
+
+
+def test_unlimited_never_evicts(tmp_path):
+    iq_generator.set_cache_budget(None)
+    for i in range(5):
+        _write(tmp_path, f"f{i}.iq", 100)
+    assert len(list(tmp_path.glob("*.iq"))) == 5
+    assert _total(tmp_path) == 500
+
+
+def test_evicts_least_recently_used(tmp_path):
+    iq_generator.set_cache_budget(250)  # room for ~2 files of 100 bytes
+    _write(tmp_path, "a.iq", 100)
+    _write(tmp_path, "b.iq", 100)
+    _write(tmp_path, "c.iq", 100)  # forces eviction of the oldest, a
+    assert not (tmp_path / "a.iq").exists()
+    assert (tmp_path / "b.iq").exists()
+    assert (tmp_path / "c.iq").exists()
+    assert _total(tmp_path) <= 250
+
+
+def test_touch_protects_recently_used(tmp_path):
+    iq_generator.set_cache_budget(250)
+    a = _write(tmp_path, "a.iq", 100)
+    _write(tmp_path, "b.iq", 100)
+    iq_generator._register_hit(a)  # a is now most-recently-used
+    _write(tmp_path, "c.iq", 100)  # should evict b, not a
+    assert (tmp_path / "a.iq").exists()
+    assert not (tmp_path / "b.iq").exists()
+    assert (tmp_path / "c.iq").exists()
+
+
+def test_reused_fixture_not_regenerated(tmp_path):
+    """A cache hit keeps the file warm so it survives later eviction pressure."""
+    iq_generator.set_cache_budget(250)
+    a = _write(tmp_path, "a.iq", 100)
+    a_mtime = a.stat().st_mtime_ns
+    _write(tmp_path, "b.iq", 100)
+    iq_generator._register_hit(a)
+    _write(tmp_path, "c.iq", 100)  # evicts b
+    assert a.exists()
+    assert a.stat().st_mtime_ns == a_mtime  # untouched on disk, never rewritten
+
+
+def test_file_larger_than_budget_still_written(tmp_path):
+    iq_generator.set_cache_budget(50)
+    _write(tmp_path, "a.iq", 40)
+    big = _write(tmp_path, "big.iq", 200)  # exceeds budget by itself
+    assert big.exists()
+    assert not (tmp_path / "a.iq").exists()  # everything else evicted to make room
+
+
+def test_hit_before_first_write_preserves_lru_order(tmp_path):
+    """A cache hit before the session's first write must not invert LRU order.
+
+    Regression: _touch must seed pre-existing files so a hit can't jump ahead
+    of older, untouched fixtures in the LRU. Without seeding in _touch, the
+    just-hit file would be evicted before the older one.
+    """
+    iq_generator.set_cache_budget(None)
+    old1 = _write(tmp_path, "old1.iq", 100)
+    old2 = _write(tmp_path, "old2.iq", 100)
+    os.utime(old1, (1000, 1000))  # old1 strictly older than old2 on disk
+    os.utime(old2, (2000, 2000))
+
+    # Fresh session with a budget; LRU not yet seeded.
+    iq_generator.set_cache_budget(250)
+    iq_generator._register_hit(old2)  # hit before any write
+    _write(tmp_path, "new.iq", 100)  # 300 > 250 → one eviction
+
+    assert old2.exists()  # recently hit → survives
+    assert not (tmp_path / "old1.iq").exists()  # oldest, untouched → evicted
+    assert (tmp_path / "new.iq").exists()
+
+
+def test_seeds_from_preexisting_files(tmp_path):
+    """Files already on disk (no --clean) are eligible for eviction."""
+    # Create pre-existing files directly, unlimited so nothing is tracked.
+    iq_generator.set_cache_budget(None)
+    _write(tmp_path, "old.iq", 100)
+    # Now impose a budget; the writer must account for the pre-existing file.
+    iq_generator.set_cache_budget(150)
+    _write(tmp_path, "new.iq", 100)  # old + new = 200 > 150 → old evicted
+    assert not (tmp_path / "old.iq").exists()
+    assert (tmp_path / "new.iq").exists()
+    assert _total(tmp_path) <= 150

--- a/system_tests/tests/test_multichannel.py
+++ b/system_tests/tests/test_multichannel.py
@@ -14,7 +14,7 @@ TODO: Add mixer tests here once mixer support is implemented in the system tests
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -43,6 +43,7 @@ def pytest_generate_tests(metafunc):
 def test_multichannel(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
@@ -53,7 +54,7 @@ def test_multichannel(
         offset_b_hz=CHANNEL_B_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_nfm.py
+++ b/system_tests/tests/test_nfm.py
@@ -9,7 +9,7 @@ Expected: MP3 contains ≈10s of audio.
 from pathlib import Path
 
 import pytest
-from conftest import CACHE_DIR, run_rtl_airband
+from conftest import run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -26,6 +26,7 @@ TIMEOUT_S = TOTAL_IQ_DURATION_S * 3 + 30  # 66 s
 def test_nfm(
     nfm_binary,
     test_output_dir: Path,
+    cache_dir: Path,
     mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
@@ -41,7 +42,7 @@ def test_nfm(
         offset_hz=CHANNEL_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_scan.py
+++ b/system_tests/tests/test_scan.py
@@ -23,7 +23,7 @@ Parametrized over all provided binaries (non-NFM and NFM if available).
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -56,6 +56,7 @@ def pytest_generate_tests(metafunc):
 def test_scan(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     mp3_tolerance: float,
     max_overrun_count: int,
     speedup_factor: float,
@@ -67,7 +68,7 @@ def test_scan(
         duration_a_s=DURATION_A_S,
         gap_s=GAP_S,
         duration_b_s=DURATION_B_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"

--- a/system_tests/tests/test_squelch_disabled.py
+++ b/system_tests/tests/test_squelch_disabled.py
@@ -11,7 +11,7 @@ mean the disabled-gate code path is gating off real signal — a regression.
 
 from pathlib import Path
 
-from conftest import CACHE_DIR, BinaryUnderTest, run_rtl_airband
+from conftest import BinaryUnderTest, run_rtl_airband
 from helpers import config_writer, iq_generator, output_validator, stats_validator
 
 SAMPLE_RATE = 2_048_000
@@ -38,6 +38,7 @@ def pytest_generate_tests(metafunc):
 def test_squelch_disabled(
     binary_under_test: BinaryUnderTest,
     test_output_dir: Path,
+    cache_dir: Path,
     max_overrun_count: int,
     speedup_factor: float,
 ) -> None:
@@ -46,7 +47,7 @@ def test_squelch_disabled(
         offset_hz=CHANNEL_OFFSET_HZ,
         audio_hz=AUDIO_TONE_HZ,
         duration_s=DURATION_S,
-        cache_dir=CACHE_DIR,
+        cache_dir=cache_dir,
     )
 
     config_path = test_output_dir / "rtl_airband.conf"


### PR DESCRIPTION
Two related changes to the Python system-test harness.

1. tmpfs-friendly IQ fixture cache - two new pytest options let it move to the small `/test_data` tmpfs:
    - `--generated-input-dir`relocates the fixture cache (previously a hardcoded path; the cache dir is now a session fixture).
    - `--generated-input-max-bytes` caps the cache with an LRU byte budget, evicting least-recently-used fixtures before each write. Default unlimited (unchanged behavior).

`platform_build.yml` points cache and output at sibling `/test_data` subdirs on the Pi runners with a 70M cap; `ubuntu-22.04-arm` keeps the default on-disk paths.

2. Fix a pre-existing xdist race - `pytest_configure` wiped the shared `test_output` dir unconditionally in *every* xdist worker. Wipes are now gated to the xdist controller, which runs `pytest_configure` before workers boot. 

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

I am making my contributions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties.


