### PR TITLE
Pin Debian base to bookworm-20260713-slim for arm/v6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # build container
-FROM debian:bookworm-slim AS build
+# Pinned: last snapshot with arm/v5, needed for the arm/v6 build (v6->v5 fallback).
+FROM debian:bookworm-20260713-slim AS build
 
 # install build dependencies
 RUN apt-get update && \
@@ -62,7 +63,8 @@ RUN ./build_dir/src/unittests
 
 
 # application container
-FROM debian:bookworm-slim
+# Pinned for arm/v6, see build stage above.
+FROM debian:bookworm-20260713-slim
 
 # install runtime dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Debian dropped the armel (arm/v5) variant from newer bookworm-slim rebuilds. The linux/arm/v6 container build relied on buildkit's v6->v5 fallback, so it broke on the rolling tag. Pin to the last snapshot that still ships arm/v5.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

I am making my contributions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties.